### PR TITLE
geom_alt props

### DIFF
--- a/data/114/190/936/1/1141909361.geojson
+++ b/data/114/190/936/1/1141909361.geojson
@@ -564,6 +564,9 @@
     },
     "wof:country":"NA",
     "wof:created":1499131068,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"91345436fba9595964034ae96009cb9e",
     "wof:hierarchy":[
         {
@@ -574,7 +577,7 @@
         }
     ],
     "wof:id":1141909361,
-    "wof:lastmodified":1566647667,
+    "wof:lastmodified":1582351981,
     "wof:name":"Windhoek",
     "wof:parent_id":85675205,
     "wof:placetype":"locality",

--- a/data/421/166/795/421166795.geojson
+++ b/data/421/166/795/421166795.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459008702,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d1bbd67fe300f42e892ffb0ab52a8f2",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421166795,
-    "wof:lastmodified":1566647643,
+    "wof:lastmodified":1582351960,
     "wof:name":"Omatako",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/170/191/421170191.geojson
+++ b/data/421/170/191/421170191.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459008842,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3287e048c887be07a74480a3b431a24",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421170191,
-    "wof:lastmodified":1566647661,
+    "wof:lastmodified":1582351967,
     "wof:name":"Gibeon",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/170/307/421170307.geojson
+++ b/data/421/170/307/421170307.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459008847,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6084aa234927971f37737be9459cf8d7",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421170307,
-    "wof:lastmodified":1566647661,
+    "wof:lastmodified":1582351966,
     "wof:name":"Epupa",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/171/383/421171383.geojson
+++ b/data/421/171/383/421171383.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459008891,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07664d76bcf4e21ec9d55f4b60dee87b",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421171383,
-    "wof:lastmodified":1566647664,
+    "wof:lastmodified":1582351981,
     "wof:name":"Khomasdal North",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/172/081/421172081.geojson
+++ b/data/421/172/081/421172081.geojson
@@ -512,7 +512,8 @@
     "qs:woe_id":1466719,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "wd:wordcount":3484,
     "wof:belongsto":[
@@ -531,6 +532,10 @@
     },
     "wof:country":"NA",
     "wof:created":1459008919,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"19855f0c8dcea26f5fd3f557dfb119d5",
     "wof:hierarchy":[
         {
@@ -542,7 +547,7 @@
         }
     ],
     "wof:id":421172081,
-    "wof:lastmodified":1561759951,
+    "wof:lastmodified":1582351961,
     "wof:name":"Windhoek",
     "wof:parent_id":421191505,
     "wof:placetype":"locality",

--- a/data/421/172/943/421172943.geojson
+++ b/data/421/172/943/421172943.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459008960,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5b424bfcd6936f1cb68372c0f173965",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421172943,
-    "wof:lastmodified":1566647650,
+    "wof:lastmodified":1582351962,
     "wof:name":"Ruacana",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/421/175/605/421175605.geojson
+++ b/data/421/175/605/421175605.geojson
@@ -194,6 +194,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d617fcfa7c2fb8959bf534ac98c80de3",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421175605,
-    "wof:lastmodified":1566647656,
+    "wof:lastmodified":1582351964,
     "wof:name":"Swakopmund",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/175/607/421175607.geojson
+++ b/data/421/175/607/421175607.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"717a4294547d0287abf435c3c448286b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421175607,
-    "wof:lastmodified":1566647656,
+    "wof:lastmodified":1582351965,
     "wof:name":"Kalahari",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/421/175/609/421175609.geojson
+++ b/data/421/175/609/421175609.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b6d4d15b8907eac9d8195ee9ab6a45b3",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421175609,
-    "wof:lastmodified":1566647657,
+    "wof:lastmodified":1582351965,
     "wof:name":"Kongola",
     "wof:parent_id":1108804901,
     "wof:placetype":"county",

--- a/data/421/175/611/421175611.geojson
+++ b/data/421/175/611/421175611.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3048765d4aa3bc12884ac74750ad87c8",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421175611,
-    "wof:lastmodified":1566647655,
+    "wof:lastmodified":1582351964,
     "wof:name":"Daures",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/175/613/421175613.geojson
+++ b/data/421/175/613/421175613.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c7fcf1429586300d8bca1d53b5f22b6e",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421175613,
-    "wof:lastmodified":1566647656,
+    "wof:lastmodified":1582351964,
     "wof:name":"Outjo",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/175/615/421175615.geojson
+++ b/data/421/175/615/421175615.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d86da625fda2300414c9ca99a74692fb",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421175615,
-    "wof:lastmodified":1566647656,
+    "wof:lastmodified":1582351964,
     "wof:name":"Arandis",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/175/621/421175621.geojson
+++ b/data/421/175/621/421175621.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff7cfa961aa4a832f579795c11c9e66a",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421175621,
-    "wof:lastmodified":1566647655,
+    "wof:lastmodified":1582351964,
     "wof:name":"Berseba",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/179/905/421179905.geojson
+++ b/data/421/179/905/421179905.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009237,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8377beb3c8cf18dad374abf22fca978",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421179905,
-    "wof:lastmodified":1566647663,
+    "wof:lastmodified":1582351981,
     "wof:name":"Tsumeb",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/421/183/083/421183083.geojson
+++ b/data/421/183/083/421183083.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009357,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64687abc51ceac0a179316fe68471ffb",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421183083,
-    "wof:lastmodified":1566647662,
+    "wof:lastmodified":1582351981,
     "wof:name":"Rehoboth East",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/183/085/421183085.geojson
+++ b/data/421/183/085/421183085.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009357,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"792469743cbc54a28c0aec147dbc3b1e",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421183085,
-    "wof:lastmodified":1566647662,
+    "wof:lastmodified":1582351981,
     "wof:name":"Uukwiyu",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/421/183/951/421183951.geojson
+++ b/data/421/183/951/421183951.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009396,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e8c6a72a7d0e6e52f933f56fda75d2f",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421183951,
-    "wof:lastmodified":1566647662,
+    "wof:lastmodified":1582351981,
     "wof:name":"Guinas",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/421/186/163/421186163.geojson
+++ b/data/421/186/163/421186163.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009472,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4954f97cddecdda1beb9633dfe3646d8",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421186163,
-    "wof:lastmodified":1566647652,
+    "wof:lastmodified":1582351962,
     "wof:name":"Otjiwarongo",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/186/171/421186171.geojson
+++ b/data/421/186/171/421186171.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009472,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f78fba76d700e61976ee8977f1a57652",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421186171,
-    "wof:lastmodified":1566647654,
+    "wof:lastmodified":1582351963,
     "wof:name":"Grootfontein",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/186/173/421186173.geojson
+++ b/data/421/186/173/421186173.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009472,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c5b41f2b2fb9c4a13ac233d51aaed1cd",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421186173,
-    "wof:lastmodified":1566647651,
+    "wof:lastmodified":1582351962,
     "wof:name":"Karibib",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/186/215/421186215.geojson
+++ b/data/421/186/215/421186215.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009474,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ede4344ff4a48eb34e7376d1c989884d",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421186215,
-    "wof:lastmodified":1566647653,
+    "wof:lastmodified":1582351963,
     "wof:name":"Windhoek Rural",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/186/223/421186223.geojson
+++ b/data/421/186/223/421186223.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009474,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b25ee9fa971271a8178034a8c9a90878",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421186223,
-    "wof:lastmodified":1566647653,
+    "wof:lastmodified":1582351963,
     "wof:name":"Mariental Rural",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/186/267/421186267.geojson
+++ b/data/421/186/267/421186267.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009475,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c713458908cadc98271caa50bdce2601",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421186267,
-    "wof:lastmodified":1566647651,
+    "wof:lastmodified":1582351962,
     "wof:name":"Omaruru",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/186/335/421186335.geojson
+++ b/data/421/186/335/421186335.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009477,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fdaa4cea9141b0969c3f0cdde75b434d",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421186335,
-    "wof:lastmodified":1566647651,
+    "wof:lastmodified":1582351962,
     "wof:name":"Omuthiyagwipundi",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/421/186/343/421186343.geojson
+++ b/data/421/186/343/421186343.geojson
@@ -207,6 +207,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009478,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"26c0b6a5811fe9016ef27bd6e2df5f2b",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421186343,
-    "wof:lastmodified":1566647654,
+    "wof:lastmodified":1582351964,
     "wof:name":"Opuwo",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/186/345/421186345.geojson
+++ b/data/421/186/345/421186345.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009478,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa5fb741d69e5afa95f73da722ffba36",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421186345,
-    "wof:lastmodified":1566647653,
+    "wof:lastmodified":1582351963,
     "wof:name":"Windhoek West",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/186/355/421186355.geojson
+++ b/data/421/186/355/421186355.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009478,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0da11495feaf90e7ef3e6966470fe59f",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421186355,
-    "wof:lastmodified":1566647651,
+    "wof:lastmodified":1582351962,
     "wof:name":"Otavi",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/186/541/421186541.geojson
+++ b/data/421/186/541/421186541.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009484,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e661bae860d2a1416f7a63ed6244e345",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421186541,
-    "wof:lastmodified":1566647653,
+    "wof:lastmodified":1582351963,
     "wof:name":"Mukwe",
     "wof:parent_id":1108804899,
     "wof:placetype":"county",

--- a/data/421/188/547/421188547.geojson
+++ b/data/421/188/547/421188547.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009569,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"df03a4db4d8ebcffbf2d942f4de49869",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":421188547,
-    "wof:lastmodified":1566647650,
+    "wof:lastmodified":1582351961,
     "wof:name":"Oranjemund",
     "wof:parent_id":421190657,
     "wof:placetype":"locality",

--- a/data/421/189/849/421189849.geojson
+++ b/data/421/189/849/421189849.geojson
@@ -245,6 +245,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009638,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc2d62d4a3cc497d81a9f5c83bdcd591",
     "wof:hierarchy":[
         {
@@ -256,7 +259,7 @@
         }
     ],
     "wof:id":421189849,
-    "wof:lastmodified":1566647649,
+    "wof:lastmodified":1582351961,
     "wof:name":"Keetmanshoop",
     "wof:parent_id":421203277,
     "wof:placetype":"locality",

--- a/data/421/189/867/421189867.geojson
+++ b/data/421/189/867/421189867.geojson
@@ -294,6 +294,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009639,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"79127d8a77a5211001f47d93703e6304",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         }
     ],
     "wof:id":421189867,
-    "wof:lastmodified":1566647649,
+    "wof:lastmodified":1582351961,
     "wof:name":"Rundu",
     "wof:parent_id":421201547,
     "wof:placetype":"locality",

--- a/data/421/190/657/421190657.geojson
+++ b/data/421/190/657/421190657.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009664,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"882eb35dbb82c98fbbefc0b60d46d900",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421190657,
-    "wof:lastmodified":1566647658,
+    "wof:lastmodified":1582351965,
     "wof:name":"Oranjemund",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/190/659/421190659.geojson
+++ b/data/421/190/659/421190659.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009664,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a437c62234851024138bf99925043ec4",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421190659,
-    "wof:lastmodified":1566647658,
+    "wof:lastmodified":1582351965,
     "wof:name":"Walvisbay Rural",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/191/505/421191505.geojson
+++ b/data/421/191/505/421191505.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009695,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b64d1616a743e5b161dae59a0fced9d",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421191505,
-    "wof:lastmodified":1566647657,
+    "wof:lastmodified":1582351965,
     "wof:name":"Windhoek East",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/195/837/421195837.geojson
+++ b/data/421/195/837/421195837.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009860,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"753bd563d4d11a9d29ed71fe520a1f5b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421195837,
-    "wof:lastmodified":1566647644,
+    "wof:lastmodified":1582351960,
     "wof:name":"Rehoboth West",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/199/731/421199731.geojson
+++ b/data/421/199/731/421199731.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459009999,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c567923e83ebdafa91f6bf6ea9d2ce7",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421199731,
-    "wof:lastmodified":1566647658,
+    "wof:lastmodified":1582351965,
     "wof:name":"Sibinda",
     "wof:parent_id":1108804901,
     "wof:placetype":"county",

--- a/data/421/199/941/421199941.geojson
+++ b/data/421/199/941/421199941.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010005,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"506c408c299d21e5ae2b0c51e1617bad",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421199941,
-    "wof:lastmodified":1566647659,
+    "wof:lastmodified":1582351965,
     "wof:name":"Katima Muliro Rural",
     "wof:parent_id":1108804901,
     "wof:placetype":"county",

--- a/data/421/200/829/421200829.geojson
+++ b/data/421/200/829/421200829.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010043,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6af45b354008c04fa15d4f512e47a54d",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421200829,
-    "wof:lastmodified":1566647659,
+    "wof:lastmodified":1582351965,
     "wof:name":"Luderitz",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/201/547/421201547.geojson
+++ b/data/421/201/547/421201547.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010076,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f632a07abc7a6f299edecb41c808bc05",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421201547,
-    "wof:lastmodified":1566647660,
+    "wof:lastmodified":1582351966,
     "wof:name":"Rundu Urban",
     "wof:parent_id":1108804903,
     "wof:placetype":"county",

--- a/data/421/201/549/421201549.geojson
+++ b/data/421/201/549/421201549.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010076,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9ffc7a7c2648a3cfce1973d31c67ea3",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421201549,
-    "wof:lastmodified":1566647660,
+    "wof:lastmodified":1582351966,
     "wof:name":"Gobabis",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/421/201/551/421201551.geojson
+++ b/data/421/201/551/421201551.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010076,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0bbc830f369698c4e6660c622e9a3b08",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":421201551,
-    "wof:lastmodified":1566647660,
+    "wof:lastmodified":1582351966,
     "wof:name":"Okahandja",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/202/645/421202645.geojson
+++ b/data/421/202/645/421202645.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010125,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a3bd60a69bdd97a67aeb56efa39252b",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421202645,
-    "wof:lastmodified":1566647647,
+    "wof:lastmodified":1582351961,
     "wof:name":"Khorixas",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/203/277/421203277.geojson
+++ b/data/421/203/277/421203277.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010146,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84c54b376e714f07a35a8ec563689f4c",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421203277,
-    "wof:lastmodified":1566647647,
+    "wof:lastmodified":1582351961,
     "wof:name":"Keetmanshoop Urban",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/203/599/421203599.geojson
+++ b/data/421/203/599/421203599.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010157,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dabdd3e07058ac48589b5f434b55834",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421203599,
-    "wof:lastmodified":1566647646,
+    "wof:lastmodified":1582351961,
     "wof:name":"Katutura East",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/204/099/421204099.geojson
+++ b/data/421/204/099/421204099.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010173,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d0504bd3c55fd008f358e990dfc649c",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421204099,
-    "wof:lastmodified":1566647646,
+    "wof:lastmodified":1582351960,
     "wof:name":"Sesfontein",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/204/103/421204103.geojson
+++ b/data/421/204/103/421204103.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"NA",
     "wof:created":1459010174,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8ff92046aaa6104a6c16b3b549ef3a8",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421204103,
-    "wof:lastmodified":1566647646,
+    "wof:lastmodified":1582351960,
     "wof:name":"Keetmanshoop Rural",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/856/325/35/85632535.geojson
+++ b/data/856/325/35/85632535.geojson
@@ -893,6 +893,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -948,6 +949,11 @@
     },
     "wof:country":"NA",
     "wof:country_alpha3":"NAM",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"d283cf8b1bc78af9016cbc0c78418abb",
     "wof:hierarchy":[
         {
@@ -964,7 +970,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647621,
+    "wof:lastmodified":1582351956,
     "wof:name":"Namibia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/325/35/85632535.geojson
+++ b/data/856/325/35/85632535.geojson
@@ -893,7 +893,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -970,7 +969,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1582351956,
+    "wof:lastmodified":1583232495,
     "wof:name":"Namibia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/751/95/85675195.geojson
+++ b/data/856/751/95/85675195.geojson
@@ -297,6 +297,9 @@
         "wk:page":"\u01c1Karas Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72417ec9fc93c2af6707c22ef0d9440a",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647624,
+    "wof:lastmodified":1582351957,
     "wof:name":"Karas",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/751/99/85675199.geojson
+++ b/data/856/751/99/85675199.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Hardap Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e13c15b07b136ad2736df4801f06f7a",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647625,
+    "wof:lastmodified":1582351958,
     "wof:name":"Hardap",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/05/85675205.geojson
+++ b/data/856/752/05/85675205.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Khomas Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52df0e9994b63078f5bc67d468ecc40b",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647617,
+    "wof:lastmodified":1582351953,
     "wof:name":"Khomas",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/09/85675209.geojson
+++ b/data/856/752/09/85675209.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Kunene Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a81c463d299b9cb1b33c7b2e98f7d9d2",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647619,
+    "wof:lastmodified":1582351954,
     "wof:name":"Kunene",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/13/85675213.geojson
+++ b/data/856/752/13/85675213.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Erongo Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75382b3c51640743c5859145525863b0",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647621,
+    "wof:lastmodified":1582351955,
     "wof:name":"Erongo",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/17/85675217.geojson
+++ b/data/856/752/17/85675217.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Otjozondjupa Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf1b22a700cdd87f946517dec7b2013c",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647618,
+    "wof:lastmodified":1582351953,
     "wof:name":"Otjozondjupa",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/23/85675223.geojson
+++ b/data/856/752/23/85675223.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Omusati Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc85226f6b2dbe0ba54e5ab103c3624d",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647620,
+    "wof:lastmodified":1582351955,
     "wof:name":"Omusati",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/27/85675227.geojson
+++ b/data/856/752/27/85675227.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Oshana Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ba5b3113708756766b6b7f920a4712a",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647617,
+    "wof:lastmodified":1582351953,
     "wof:name":"Oshana",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/31/85675231.geojson
+++ b/data/856/752/31/85675231.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Ohangwena Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0124a226d369aed0e45ee1d9365168de",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647620,
+    "wof:lastmodified":1582351955,
     "wof:name":"Ohangwena",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/35/85675235.geojson
+++ b/data/856/752/35/85675235.geojson
@@ -243,6 +243,9 @@
         "wk:page":"Omaheke Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05deba3d7534f783f0960f64cddaa208",
     "wof:hierarchy":[
         {
@@ -260,7 +263,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647617,
+    "wof:lastmodified":1582351952,
     "wof:name":"Omaheke",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/43/85675243.geojson
+++ b/data/856/752/43/85675243.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Oshikoto Region"
     },
     "wof:country":"NA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed5381783b4be2eaf744b50433838d7c",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647619,
+    "wof:lastmodified":1582351954,
     "wof:name":"Oshikoto",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/890/440/187/890440187.geojson
+++ b/data/890/440/187/890440187.geojson
@@ -273,6 +273,9 @@
     },
     "wof:country":"NA",
     "wof:created":1469052266,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"909f0b1d680656f00f5cec80cfae62e0",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
         }
     ],
     "wof:id":890440187,
-    "wof:lastmodified":1566647665,
+    "wof:lastmodified":1582351981,
     "wof:name":"Opuwo",
     "wof:parent_id":421186343,
     "wof:placetype":"locality",

--- a/data/890/443/131/890443131.geojson
+++ b/data/890/443/131/890443131.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"NA",
     "wof:created":1469052402,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ed97250b9435699f360eff0104e82ab",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":890443131,
-    "wof:lastmodified":1566647665,
+    "wof:lastmodified":1582351981,
     "wof:name":"Walvisbay Urban",
     "wof:parent_id":85675213,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.