### PR TITLE
Name updates

### DIFF
--- a/data/856/325/35/85632535.geojson
+++ b/data/856/325/35/85632535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":72.255333,
-    "geom:area_square_m":826263721089.597778,
+    "geom:area_square_m":826263721032.19519,
     "geom:bbox":"11.734472,-28.970639,25.261752,-16.963485",
     "geom:latitude":-22.139622,
     "geom:longitude":17.222159,
@@ -54,6 +54,9 @@
     "name:arg_x_preferred":[
         "Namibia"
     ],
+    "name:ary_x_preferred":[
+        "\u0646\u0627\u0645\u064a\u0628\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0646\u0627\u0645\u064a\u0628\u064a\u0627"
     ],
@@ -74,6 +77,9 @@
     ],
     "name:bam_x_variant":[
         "Namibi"
+    ],
+    "name:ban_x_preferred":[
+        "Namibia"
     ],
     "name:bar_x_preferred":[
         "Namibia"
@@ -153,6 +159,12 @@
     "name:dan_x_preferred":[
         "Namibia"
     ],
+    "name:deu_at_x_preferred":[
+        "Namibia"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Namibia"
+    ],
     "name:deu_x_preferred":[
         "Namibia"
     ],
@@ -167,6 +179,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039d\u03b1\u03bc\u03af\u03bc\u03c0\u03b9\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Namibia"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Namibia"
     ],
     "name:eng_x_preferred":[
         "Namibia"
@@ -228,6 +246,9 @@
     "name:gag_x_preferred":[
         "Namibiya"
     ],
+    "name:gcr_x_preferred":[
+        "Namibi"
+    ],
     "name:ger_x_variant":[
         "Republik Namibia"
     ],
@@ -242,6 +263,9 @@
     ],
     "name:glv_x_preferred":[
         "Yn Nameeb"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf3d\ud800\udf30\ud800\udf3c\ud800\udf39\ud800\udf31\ud800\udf3e\ud800\udf30"
     ],
     "name:grn_x_preferred":[
         "Nam\u00edvia"
@@ -474,6 +498,9 @@
     "name:mon_x_variant":[
         "\u041d\u0430\u043c\u0438\u0431\u0438"
     ],
+    "name:mri_x_preferred":[
+        "Nam\u012bpia"
+    ],
     "name:msa_x_preferred":[
         "Namibia"
     ],
@@ -524,6 +551,9 @@
     ],
     "name:nov_x_preferred":[
         "Namibia"
+    ],
+    "name:nqo_x_preferred":[
+        "\u07e3\u07ca\u07e1\u07d3\u07cc\u07eb"
     ],
     "name:nso_x_preferred":[
         "Namibia"
@@ -578,6 +608,9 @@
     ],
     "name:pol_x_preferred":[
         "Namibia"
+    ],
+    "name:por_br_x_preferred":[
+        "Nam\u00edbia"
     ],
     "name:por_x_preferred":[
         "Nam\u00edbia"
@@ -639,6 +672,9 @@
     "name:sna_x_preferred":[
         "Namibia"
     ],
+    "name:snd_x_preferred":[
+        "\u0646\u0645\u064a\u0628\u064a\u0627"
+    ],
     "name:som_x_preferred":[
         "Namibiya"
     ],
@@ -661,6 +697,9 @@
     "name:srd_x_preferred":[
         "Nam\u00ecbia"
     ],
+    "name:srp_el_x_preferred":[
+        "Namibija"
+    ],
     "name:srp_x_preferred":[
         "\u041d\u0430\u043c\u0438\u0431\u0438\u0458\u0430"
     ],
@@ -681,6 +720,9 @@
     ],
     "name:szl_x_preferred":[
         "Namibijo"
+    ],
+    "name:szy_x_preferred":[
+        "Namibia"
     ],
     "name:tam_x_preferred":[
         "\u0ba8\u0bae\u0bc0\u0baa\u0bbf\u0baf\u0bbe"
@@ -723,6 +765,9 @@
     ],
     "name:tur_x_preferred":[
         "Namibya"
+    ],
+    "name:twi_x_preferred":[
+        "Namibia"
     ],
     "name:udm_x_preferred":[
         "\u041d\u0430\u043c\u0438\u0431\u0438\u044f"
@@ -800,8 +845,26 @@
     "name:zha_x_preferred":[
         "Namibia"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u7eb3\u7c73\u6bd4\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7d0d\u7c73\u6bd4\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Namibia"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u7eb3\u7c73\u6bd4\u4e9a"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u7eb3\u7c73\u6bd4\u4e9a"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u7eb3\u7c73\u6bd4\u4e9a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u7d0d\u7c73\u6bd4\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u7eb3\u7c73\u6bd4\u4e9a"
@@ -970,7 +1033,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1583797399,
+    "wof:lastmodified":1587428979,
     "wof:name":"Namibia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.