### PR TITLE
na concordances, placetype local, and more

### DIFF
--- a/data/110/878/506/3/1108785063.geojson
+++ b/data/110/878/506/3/1108785063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.14677,
-    "geom:area_square_m":13011868745.141815,
+    "geom:area_square_m":13011868636.102514,
     "geom:bbox":"18.340356,-23.870628,19.999111,-22.998057",
     "geom:latitude":-23.418518,
     "geom:longitude":19.296405,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OH.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835145,
-    "wof:geomhash":"89ed06033304c6cde5b4763be39aaeb1",
+    "wof:geomhash":"c578232929cb00fa2df2106da05d343b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785063,
-    "wof:lastmodified":1627522456,
+    "wof:lastmodified":1695886074,
     "wof:name":"Aminius",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/110/878/506/5/1108785065.geojson
+++ b/data/110/878/506/5/1108785065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030163,
-    "geom:area_square_m":355698566.169494,
+    "geom:area_square_m":355698498.125334,
     "geom:bbox":"14.990653,-17.639643,15.27328,-17.391157",
     "geom:latitude":-17.505772,
     "geom:longitude":15.10443,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835146,
-    "wof:geomhash":"92d8385504f90cebf3168646e095510b",
+    "wof:geomhash":"6c4cddc05541bea20ef8dd6ed196847d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108785065,
-    "wof:lastmodified":1627522456,
+    "wof:lastmodified":1695886074,
     "wof:name":"Anamulenge",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/506/7/1108785067.geojson
+++ b/data/110/878/506/7/1108785067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094876,
-    "geom:area_square_m":1117809722.11903,
+    "geom:area_square_m":1117809722.118943,
     "geom:bbox":"16.1516845858,-17.9189968244,16.5802336347,-17.4466805853",
     "geom:latitude":-17.670626,
     "geom:longitude":16.352648,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.EH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835148,
-    "wof:geomhash":"288e72a3050bdac5c67c926bb829e505",
+    "wof:geomhash":"83605746d4a15589ce58b9da82cb33a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785067,
-    "wof:lastmodified":1566647636,
+    "wof:lastmodified":1695886416,
     "wof:name":"Eenhana",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/507/1/1108785071.geojson
+++ b/data/110/878/507/1/1108785071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037968,
-    "geom:area_square_m":446951071.525794,
+    "geom:area_square_m":446951071.525795,
     "geom:bbox":"15.2567285821,-17.9749845778,15.585684477,-17.6701548546",
     "geom:latitude":-17.822219,
     "geom:longitude":15.413479,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835149,
-    "wof:geomhash":"bd863eebf33719c201dc3a8d01683fc9",
+    "wof:geomhash":"6fa5e8d25f215740fb02663a63a9b9ca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108785071,
-    "wof:lastmodified":1566647637,
+    "wof:lastmodified":1695886416,
     "wof:name":"Elim",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/507/5/1108785075.geojson
+++ b/data/110/878/507/5/1108785075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027844,
-    "geom:area_square_m":328136971.661966,
+    "geom:area_square_m":328136896.226667,
     "geom:bbox":"15.659958,-17.687314,15.954391,-17.557541",
     "geom:latitude":-17.625806,
     "geom:longitude":15.820994,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.ED"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835150,
-    "wof:geomhash":"07108960f46f82861b419e00bbe421ee",
+    "wof:geomhash":"8140488c4905e2060f8d6f563e3dc60e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785075,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886075,
     "wof:name":"Endola",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/507/7/1108785077.geojson
+++ b/data/110/878/507/7/1108785077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025226,
-    "geom:area_square_m":297463345.673942,
+    "geom:area_square_m":297463524.712747,
     "geom:bbox":"15.618077,-17.671784,15.894907,-17.390762",
     "geom:latitude":-17.517615,
     "geom:longitude":15.749336,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.EG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835151,
-    "wof:geomhash":"2ec9daeb767044514539e378b8a3a9c6",
+    "wof:geomhash":"1d4f228328a7c2d17d4b1c19cfd82564",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108785077,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886075,
     "wof:name":"Engela",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/507/9/1108785079.geojson
+++ b/data/110/878/507/9/1108785079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.666962,
-    "geom:area_square_m":7834801532.262156,
+    "geom:area_square_m":7834801011.815366,
     "geom:bbox":"16.520352,-18.539284,18.001079,-17.902828",
     "geom:latitude":-18.193345,
     "geom:longitude":17.332165,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OT.EG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835152,
-    "wof:geomhash":"5bd1f2c993c26d1acdee1ea46797e5b9",
+    "wof:geomhash":"44d012292ad12ad571153d5925222208",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785079,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886076,
     "wof:name":"Engodi",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/110/878/508/1/1108785081.geojson
+++ b/data/110/878/508/1/1108785081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154257,
-    "geom:area_square_m":1817449607.379322,
+    "geom:area_square_m":1817449629.503613,
     "geom:bbox":"16.351443,-17.928992,16.993743,-17.441612",
     "geom:latitude":-17.667864,
     "geom:longitude":16.685815,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835158,
-    "wof:geomhash":"fe45460ffe278daf1dc9a5d856b47c12",
+    "wof:geomhash":"1e231113fe128a900aa2ebe761fa7eea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785081,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886076,
     "wof:name":"Epembe",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/508/3/1108785083.geojson
+++ b/data/110/878/508/3/1108785083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.958964,
-    "geom:area_square_m":11074882582.799871,
+    "geom:area_square_m":11074882719.722021,
     "geom:bbox":"19.288214,-21.690494,20.020994,-20.240375",
     "geom:latitude":-20.933208,
     "geom:longitude":19.649233,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OH.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835159,
-    "wof:geomhash":"c286237e1e86986f10ee2c4331088b07",
+    "wof:geomhash":"6d0c2d59fe1e84a95075dcbcfc04cc2b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785083,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886076,
     "wof:name":"Epukiro",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/110/878/508/5/1108785085.geojson
+++ b/data/110/878/508/5/1108785085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054837,
-    "geom:area_square_m":646516016.31437,
+    "geom:area_square_m":646516021.225773,
     "geom:bbox":"15.366253,-17.736572,15.654573,-17.390717",
     "geom:latitude":-17.546494,
     "geom:longitude":15.519587,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.ET"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835161,
-    "wof:geomhash":"3bfac9166e658079e4d81b9ab6a24f19",
+    "wof:geomhash":"4d649d1fb562eee573bd329abf12dd93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785085,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886076,
     "wof:name":"Etayi",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/508/9/1108785089.geojson
+++ b/data/110/878/508/9/1108785089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177268,
-    "geom:area_square_m":2088546213.637526,
+    "geom:area_square_m":2088546213.637648,
     "geom:bbox":"24.3462777681,-17.8855295869,25.261752,-17.469636",
     "geom:latitude":-17.668662,
     "geom:longitude":24.795405,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NA.CA.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835164,
-    "wof:geomhash":"7bf57e2ed7b5dff870de7125b7c92191",
+    "wof:geomhash":"38d2bd275eae9c01cc5dc2db7f40065b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108785089,
-    "wof:lastmodified":1566647635,
+    "wof:lastmodified":1695886416,
     "wof:name":"Kabe",
     "wof:parent_id":85675247,
     "wof:placetype":"county",

--- a/data/110/878/509/1/1108785091.geojson
+++ b/data/110/878/509/1/1108785091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.753137,
-    "geom:area_square_m":8842402794.259901,
+    "geom:area_square_m":8842402430.552572,
     "geom:bbox":"18.463973,-18.806278,19.27441,-17.660646",
     "geom:latitude":-18.28411,
     "geom:longitude":18.86162,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OK.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835165,
-    "wof:geomhash":"73711cafc207b16c137072306c26331a",
+    "wof:geomhash":"daa56e4ae1ac1423d0db02d6c635e1d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108785091,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886076,
     "wof:name":"Kahenge",
     "wof:parent_id":85675237,
     "wof:placetype":"county",

--- a/data/110/878/509/3/1108785093.geojson
+++ b/data/110/878/509/3/1108785093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.474205,
-    "geom:area_square_m":17150550173.869324,
+    "geom:area_square_m":17150550173.869091,
     "geom:bbox":"14.4666792082,-20.5625940805,15.9961550427,-19.1931621991",
     "geom:latitude":-19.802738,
     "geom:longitude":15.324484,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KU.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835166,
-    "wof:geomhash":"886a11739e5f76c0d71b75616752bedc",
+    "wof:geomhash":"41fc54d6109ed2aaec10dd02f0a3466d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108785093,
-    "wof:lastmodified":1566647639,
+    "wof:lastmodified":1695886416,
     "wof:name":"Kamanjab",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/110/878/509/5/1108785095.geojson
+++ b/data/110/878/509/5/1108785095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.528143,
-    "geom:area_square_m":6190839274.059194,
+    "geom:area_square_m":6190838934.583982,
     "geom:bbox":"19.199361,-19.184124,19.740542,-17.821895",
     "geom:latitude":-18.559348,
     "geom:longitude":19.435452,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KW.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835168,
-    "wof:geomhash":"19d4b6325fe0b7f71ee3ef1f7ebd5475",
+    "wof:geomhash":"072d0edc9d7b37e5a4e4c8eb793aa9bc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785095,
-    "wof:lastmodified":1627522458,
+    "wof:lastmodified":1695886077,
     "wof:name":"Kapako",
     "wof:parent_id":85675237,
     "wof:placetype":"county",

--- a/data/110/878/509/7/1108785097.geojson
+++ b/data/110/878/509/7/1108785097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.514961,
-    "geom:area_square_m":38341300393.813843,
+    "geom:area_square_m":38341300325.792381,
     "geom:bbox":"17.170711,-28.970639,19.999271,-27.137693",
     "geom:latitude":-28.093661,
     "geom:longitude":18.71277,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KA.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835169,
-    "wof:geomhash":"a6a62d18427acab6eb6e0a38a68270dc",
+    "wof:geomhash":"b26578e5ae9d9ea99e8ba4021fa6a87a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108785097,
-    "wof:lastmodified":1636502200,
+    "wof:lastmodified":1695886049,
     "wof:name":"Karas",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/110/878/509/9/1108785099.geojson
+++ b/data/110/878/509/9/1108785099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002796,
-    "geom:area_square_m":32966312.82483,
+    "geom:area_square_m":32966394.073666,
     "geom:bbox":"24.23664,-17.540323,24.320267,-17.484214",
     "geom:latitude":-17.509072,
     "geom:longitude":24.278949,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.CA.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835171,
-    "wof:geomhash":"293c1ec9f5a1b5c3f855b8a4d196176b",
+    "wof:geomhash":"dbdeed23ff09ec26e2e4afb7c50ec1b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785099,
-    "wof:lastmodified":1627522458,
+    "wof:lastmodified":1695886077,
     "wof:name":"Katima Muliro Urban",
     "wof:parent_id":85675247,
     "wof:placetype":"county",

--- a/data/110/878/510/1/1108785101.geojson
+++ b/data/110/878/510/1/1108785101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000167,
-    "geom:area_square_m":1906702.953122,
+    "geom:area_square_m":1906665.157438,
     "geom:bbox":"17.045875,-22.532869,17.059342,-22.513543",
     "geom:latitude":-22.523984,
     "geom:longitude":17.052808,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KH.KC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835172,
-    "wof:geomhash":"6936e848a6b1826a9f5a74c8ce3b2c3f",
+    "wof:geomhash":"11be32a4e1091d073a98b59d20328d9e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785101,
-    "wof:lastmodified":1627522458,
+    "wof:lastmodified":1695886077,
     "wof:name":"Katutura Central",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/110/878/510/3/1108785103.geojson
+++ b/data/110/878/510/3/1108785103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.322462,
-    "geom:area_square_m":3790198678.397327,
+    "geom:area_square_m":3790197259.713969,
     "geom:bbox":"23.295031,-18.502285,24.095266,-17.763823",
     "geom:latitude":-18.090126,
     "geom:longitude":23.668876,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.CA.LY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835176,
-    "wof:geomhash":"94da9dea5913feae62e0afd073447cec",
+    "wof:geomhash":"2aeb6d309e7b42ae31ecbb9a2a4f406f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785103,
-    "wof:lastmodified":1627522458,
+    "wof:lastmodified":1695886078,
     "wof:name":"Linyandi",
     "wof:parent_id":85675247,
     "wof:placetype":"county",

--- a/data/110/878/510/7/1108785107.geojson
+++ b/data/110/878/510/7/1108785107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.528939,
-    "geom:area_square_m":5951191293.341379,
+    "geom:area_square_m":5951190491.230233,
     "geom:bbox":"17.118228,-24.956876,18.005165,-24.038966",
     "geom:latitude":-24.506376,
     "geom:longitude":17.552482,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"NA.HA.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835178,
-    "wof:geomhash":"8ede9f965459b9d07765857f13e1fa45",
+    "wof:geomhash":"34a749b6b7d6663832de80db8181b51c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108785107,
-    "wof:lastmodified":1627522458,
+    "wof:lastmodified":1695886078,
     "wof:name":"Mariental Urban",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/110/878/510/9/1108785109.geojson
+++ b/data/110/878/510/9/1108785109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.79603,
-    "geom:area_square_m":9327240737.924726,
+    "geom:area_square_m":9327241387.83456,
     "geom:bbox":"19.469117,-19.184094,20.420311,-17.861548",
     "geom:latitude":-18.627647,
     "geom:longitude":20.089058,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KE.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835179,
-    "wof:geomhash":"02a70f90b15a32305ff02659382b037c",
+    "wof:geomhash":"4b95ad7448e1a5a6997e1d2b6fd1b479",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108785109,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886078,
     "wof:name":"Mashare",
     "wof:parent_id":85675237,
     "wof:placetype":"county",

--- a/data/110/878/511/1/1108785111.geojson
+++ b/data/110/878/511/1/1108785111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003194,
-    "geom:area_square_m":36496260.692959,
+    "geom:area_square_m":36496221.638356,
     "geom:bbox":"17.004075,-22.511848,17.088102,-22.433227",
     "geom:latitude":-22.468536,
     "geom:longitude":17.045084,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KH.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835180,
-    "wof:geomhash":"28ffca26b53d9f7e2cb789dece3ccd60",
+    "wof:geomhash":"c60825dd05c764b12050a468e24d44b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108785111,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886078,
     "wof:name":"Moses Garoeb",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/110/878/511/3/1108785113.geojson
+++ b/data/110/878/511/3/1108785113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.696067,
-    "geom:area_square_m":8183339690.968024,
+    "geom:area_square_m":8183340339.285253,
     "geom:bbox":"17.997673,-18.763217,18.656826,-17.389509",
     "geom:latitude":-18.047713,
     "geom:longitude":18.258845,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KW.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835181,
-    "wof:geomhash":"2c3034bd8ed809c28fbb58375653d5ba",
+    "wof:geomhash":"757ba29c224111c3ec8eacb2d2514ceb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785113,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886078,
     "wof:name":"Mpungu",
     "wof:parent_id":85675237,
     "wof:placetype":"county",

--- a/data/110/878/511/5/1108785115.geojson
+++ b/data/110/878/511/5/1108785115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.694916,
-    "geom:area_square_m":8144602422.168012,
+    "geom:area_square_m":8144602554.269946,
     "geom:bbox":"20.415257,-19.183984,21.004726,-17.906235",
     "geom:latitude":-18.583334,
     "geom:longitude":20.705889,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KE.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835182,
-    "wof:geomhash":"3e1b20e8970a8157b480f6d9438117ef",
+    "wof:geomhash":"d72bb40334a4ed2dee773ec3f076e7b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785115,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886079,
     "wof:name":"Ndiyona",
     "wof:parent_id":85675237,
     "wof:placetype":"county",

--- a/data/110/878/511/7/1108785117.geojson
+++ b/data/110/878/511/7/1108785117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06878,
-    "geom:area_square_m":810119376.455026,
+    "geom:area_square_m":810119355.583051,
     "geom:bbox":"15.006439,-17.887719,15.34854,-17.533546",
     "geom:latitude":-17.721987,
     "geom:longitude":15.170379,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.OG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835183,
-    "wof:geomhash":"9c5d5bf9da8bd9ef1374936b619a0a75",
+    "wof:geomhash":"9c166a28b59e448dbd3669ca66e7cfe9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785117,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886079,
     "wof:name":"Ogongo",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/511/9/1108785119.geojson
+++ b/data/110/878/511/9/1108785119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014663,
-    "geom:area_square_m":172897194.238748,
+    "geom:area_square_m":172897045.819382,
     "geom:bbox":"15.761525,-17.560475,15.997182,-17.457949",
     "geom:latitude":-17.521018,
     "geom:longitude":15.883359,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.OW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835184,
-    "wof:geomhash":"1ebb082a7d5ee555db2245b475de3790",
+    "wof:geomhash":"10223c2c6df2b25ff7d0072036996dda",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785119,
-    "wof:lastmodified":1636502200,
+    "wof:lastmodified":1695886049,
     "wof:name":"Ohangwena",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/512/1/1108785121.geojson
+++ b/data/110/878/512/1/1108785121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.847924,
-    "geom:area_square_m":9931394463.512077,
+    "geom:area_square_m":9931394463.511864,
     "geom:bbox":"14.352499129,-19.4203785339,15.2691229104,-17.8487376897",
     "geom:latitude":-18.694283,
     "geom:longitude":14.876286,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.OK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835186,
-    "wof:geomhash":"cb2b045338b1c8571adc278cb9ac99f0",
+    "wof:geomhash":"21a6c9de411a3aff579f8d2d779f4369",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108785121,
-    "wof:lastmodified":1566647641,
+    "wof:lastmodified":1695886416,
     "wof:name":"Okahao",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/512/5/1108785125.geojson
+++ b/data/110/878/512/5/1108785125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.265914,
-    "geom:area_square_m":14672466648.215755,
+    "geom:area_square_m":14672466935.763336,
     "geom:bbox":"17.34868,-21.081014,19.003105,-19.523244",
     "geom:latitude":-20.387492,
     "geom:longitude":18.335943,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OD.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835187,
-    "wof:geomhash":"e81951cd281e608e1031adb8a1399c22",
+    "wof:geomhash":"f868ec7befc6c92eff9d0ee8bb66bf15",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108785125,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886079,
     "wof:name":"Okakarara",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/110/878/512/7/1108785127.geojson
+++ b/data/110/878/512/7/1108785127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020246,
-    "geom:area_square_m":238430762.413735,
+    "geom:area_square_m":238430726.782948,
     "geom:bbox":"15.807338,-17.86089,16.000902,-17.68129",
     "geom:latitude":-17.752445,
     "geom:longitude":15.931017,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835188,
-    "wof:geomhash":"d6965925fed50f6007a50b33562144ac",
+    "wof:geomhash":"ef8a5d8429ea0eb85e2e32948d3571c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785127,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886079,
     "wof:name":"Okaku",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/512/9/1108785129.geojson
+++ b/data/110/878/512/9/1108785129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055771,
-    "geom:area_square_m":657701032.054186,
+    "geom:area_square_m":657701072.189869,
     "geom:bbox":"15.068915,-17.641086,15.462105,-17.39085",
     "geom:latitude":-17.501027,
     "geom:longitude":15.288956,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835189,
-    "wof:geomhash":"6797bfab97a6ef96826ad47af6461911",
+    "wof:geomhash":"7c1a7a5c45ad125dc5569823060e7abb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108785129,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886079,
     "wof:name":"Okalongo",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/513/1/1108785131.geojson
+++ b/data/110/878/513/1/1108785131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302827,
-    "geom:area_square_m":3563695058.098314,
+    "geom:area_square_m":3563695694.641543,
     "geom:bbox":"16.408715,-18.139146,18.001514,-17.749569",
     "geom:latitude":-17.878214,
     "geom:longitude":17.179743,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OT.OO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835190,
-    "wof:geomhash":"224651a25609da2e2ba045422a654ddd",
+    "wof:geomhash":"91bf9e39b0d13ccf61e29587dd09a15b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785131,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886079,
     "wof:name":"Okankolo",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/110/878/513/3/1108785133.geojson
+++ b/data/110/878/513/3/1108785133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036241,
-    "geom:area_square_m":426627739.442598,
+    "geom:area_square_m":426627713.638074,
     "geom:bbox":"15.389298,-18.007517,15.799706,-17.670628",
     "geom:latitude":-17.821303,
     "geom:longitude":15.573728,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835191,
-    "wof:geomhash":"70856ada1f182ad322a47219a1d5938d",
+    "wof:geomhash":"4c556c9e6d3e0aa20ddd1e3cde5fb26d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785133,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886080,
     "wof:name":"Okatana",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/513/5/1108785135.geojson
+++ b/data/110/878/513/5/1108785135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047805,
-    "geom:area_square_m":561695301.337783,
+    "geom:area_square_m":561695071.144646,
     "geom:bbox":"15.759889,-18.388485,16.039896,-18.020476",
     "geom:latitude":-18.154271,
     "geom:longitude":15.924923,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835192,
-    "wof:geomhash":"19ef8609b9d0a723af6b713157621104",
+    "wof:geomhash":"fdf16c8ab3b170db937d6a4043e7120c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785135,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886080,
     "wof:name":"Okatyali",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/513/7/1108785137.geojson
+++ b/data/110/878/513/7/1108785137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.398861,
-    "geom:area_square_m":4701873562.565791,
+    "geom:area_square_m":4701873221.580832,
     "geom:bbox":"16.873975,-17.768725,18.002351,-17.389528",
     "geom:latitude":-17.571105,
     "geom:longitude":17.455832,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.OO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835193,
-    "wof:geomhash":"c9129459110c6cc21a4763f48065082d",
+    "wof:geomhash":"fbcbd7d0b449765debb71e0f490627cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785137,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886080,
     "wof:name":"Okongo",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/513/9/1108785139.geojson
+++ b/data/110/878/513/9/1108785139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020638,
-    "geom:area_square_m":242654329.424358,
+    "geom:area_square_m":242654312.25088,
     "geom:bbox":"15.998634,-18.160402,16.137046,-17.924379",
     "geom:latitude":-18.038786,
     "geom:longitude":16.068616,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OT.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835194,
-    "wof:geomhash":"4d352ef28d64df905912c6e20fa21e7c",
+    "wof:geomhash":"c446aae0b84836d0bc8cc50af5d86e9e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785139,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886080,
     "wof:name":"Olukonda",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/110/878/514/3/1108785143.geojson
+++ b/data/110/878/514/3/1108785143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039835,
-    "geom:area_square_m":468423387.538512,
+    "geom:area_square_m":468423566.686762,
     "geom:bbox":"15.49967,-18.161723,15.796059,-17.933404",
     "geom:latitude":-18.011551,
     "geom:longitude":15.659466,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835196,
-    "wof:geomhash":"29913dad15ab67d2c40437cb22a71969",
+    "wof:geomhash":"90798ada8cf468b91ba5e07442974edd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785143,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886080,
     "wof:name":"Ompundja",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/514/5/1108785145.geojson
+++ b/data/110/878/514/5/1108785145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050957,
-    "geom:area_square_m":600417931.706488,
+    "geom:area_square_m":600417894.71138,
     "geom:bbox":"15.921493,-17.795468,16.259591,-17.519579",
     "geom:latitude":-17.654084,
     "geom:longitude":16.09394,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835197,
-    "wof:geomhash":"59dc891643a450331490b1ae12efa011",
+    "wof:geomhash":"351c5d2223dc3c3265d379515e639c69",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785145,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886081,
     "wof:name":"Omulonga",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/514/7/1108785147.geojson
+++ b/data/110/878/514/7/1108785147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052712,
-    "geom:area_square_m":621798092.758445,
+    "geom:area_square_m":621798313.001841,
     "geom:bbox":"16.311158,-17.58005,16.877942,-17.389919",
     "geom:latitude":-17.449528,
     "geom:longitude":16.579277,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.ON"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835198,
-    "wof:geomhash":"fe7bf15b577086b64c06cd57516f4d17",
+    "wof:geomhash":"9ad9c63f8e5548eaf13dc0c90a99da60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785147,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886081,
     "wof:name":"Omundaungilo",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/514/9/1108785149.geojson
+++ b/data/110/878/514/9/1108785149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153973,
-    "geom:area_square_m":1807427837.333303,
+    "geom:area_square_m":1807428424.508094,
     "geom:bbox":"15.937641,-18.502887,16.412964,-18.051319",
     "geom:latitude":-18.317922,
     "geom:longitude":16.18043,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OT.OT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835199,
-    "wof:geomhash":"b547c9c267787e4ebe6c5950249ecb9b",
+    "wof:geomhash":"935880197192f94fa1faaac0a9c22f40",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785149,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886081,
     "wof:name":"Omuntele",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/110/878/515/1/1108785151.geojson
+++ b/data/110/878/515/1/1108785151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037616,
-    "geom:area_square_m":442487667.488648,
+    "geom:area_square_m":442487672.593531,
     "geom:bbox":"16.110851,-18.142408,16.351553,-17.787206",
     "geom:latitude":-17.949527,
     "geom:longitude":16.208652,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OT.ON"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835201,
-    "wof:geomhash":"187ff559438873a7ec6774dcbdeca23c",
+    "wof:geomhash":"d35316bb52e2e48863950219e9a4df9e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108785151,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886081,
     "wof:name":"Onayena",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/110/878/515/3/1108785153.geojson
+++ b/data/110/878/515/3/1108785153.geojson
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835202,
-    "wof:geomhash":"b44e4b777e0b5158e8da2cc82fdad56a",
+    "wof:geomhash":"b2b507cedad3ea0e98a8d74e0681b921",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108785153,
-    "wof:lastmodified":1566647643,
+    "wof:lastmodified":1695886417,
     "wof:name":"Ondangwa",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/515/5/1108785155.geojson
+++ b/data/110/878/515/5/1108785155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042014,
-    "geom:area_square_m":495528650.082659,
+    "geom:area_square_m":495528531.313961,
     "geom:bbox":"16.035264,-17.592728,16.332088,-17.390386",
     "geom:latitude":-17.476575,
     "geom:longitude":16.184193,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.OD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835203,
-    "wof:geomhash":"5dc1276a82b5c15b1f33dfd85276e65d",
+    "wof:geomhash":"6462ed82449834cc5784ff2ead365f63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785155,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886081,
     "wof:name":"Ondobe",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/515/7/1108785157.geojson
+++ b/data/110/878/515/7/1108785157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051692,
-    "geom:area_square_m":609334563.586111,
+    "geom:area_square_m":609334596.464873,
     "geom:bbox":"14.540613,-17.74694,14.784419,-17.391424",
     "geom:latitude":-17.577561,
     "geom:longitude":14.627403,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.ON"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835204,
-    "wof:geomhash":"80672b0aadad26d53e90e8bd14234e7f",
+    "wof:geomhash":"0d85d2d4a939b3c35b22fdf35e0e9565",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785157,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886081,
     "wof:name":"Onesi",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/516/1/1108785161.geojson
+++ b/data/110/878/516/1/1108785161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027155,
-    "geom:area_square_m":320328806.75683,
+    "geom:area_square_m":320328748.338419,
     "geom:bbox":"15.550685,-17.555622,15.843619,-17.390621",
     "geom:latitude":-17.4476,
     "geom:longitude":15.667896,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.OG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835205,
-    "wof:geomhash":"8cf009570811f58ff1b8c04fe4679a61",
+    "wof:geomhash":"802d076faa063f2cfa3d5fbe45208d32",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785161,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Ongenga",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/516/3/1108785163.geojson
+++ b/data/110/878/516/3/1108785163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017917,
-    "geom:area_square_m":210960743.043417,
+    "geom:area_square_m":210960714.689039,
     "geom:bbox":"15.734215,-17.867907,15.956503,-17.681452",
     "geom:latitude":-17.782674,
     "geom:longitude":15.82929,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835206,
-    "wof:geomhash":"e5e82f16acfb9d74dcbcd77baa2a67a9",
+    "wof:geomhash":"e49b563e7e551f704da143af278a899c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108785163,
-    "wof:lastmodified":1636502200,
+    "wof:lastmodified":1695886049,
     "wof:name":"Ongwediva",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/516/5/1108785165.geojson
+++ b/data/110/878/516/5/1108785165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031739,
-    "geom:area_square_m":373573923.315777,
+    "geom:area_square_m":373573919.215351,
     "geom:bbox":"15.998257,-17.990063,16.150614,-17.692886",
     "geom:latitude":-17.845348,
     "geom:longitude":16.070011,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OT.OP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835207,
-    "wof:geomhash":"54a25db2ed9e4e600f90f4bb25d2c850",
+    "wof:geomhash":"bdd91627d50afa9bdbd677ee1cd4af64",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108785165,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Oniipa",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/110/878/516/7/1108785167.geojson
+++ b/data/110/878/516/7/1108785167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048122,
-    "geom:area_square_m":565686548.647001,
+    "geom:area_square_m":565686574.200921,
     "geom:bbox":"16.216932,-18.21738,16.527626,-17.916751",
     "geom:latitude":-18.072474,
     "geom:longitude":16.37866,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OT.OY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835208,
-    "wof:geomhash":"cf3b98c84cefb4e48a11bebc02257e46",
+    "wof:geomhash":"1b92988243e25e752fb88963f9ad0786",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785167,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886081,
     "wof:name":"Onyaanya",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/110/878/516/9/1108785169.geojson
+++ b/data/110/878/516/9/1108785169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016065,
-    "geom:area_square_m":189074792.059142,
+    "geom:area_square_m":189074767.005144,
     "geom:bbox":"15.680465,-17.937022,15.80255,-17.74937",
     "geom:latitude":-17.862176,
     "geom:longitude":15.735896,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835210,
-    "wof:geomhash":"30412b9fe09302faa89dac88552beacb",
+    "wof:geomhash":"8bc9bf687192c66d2463f71005eb582c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785169,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Oshakati East",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/517/1/1108785171.geojson
+++ b/data/110/878/517/1/1108785171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020278,
-    "geom:area_square_m":238654318.020458,
+    "geom:area_square_m":238654406.148719,
     "geom:bbox":"15.536751,-17.934849,15.72651,-17.748215",
     "geom:latitude":-17.858233,
     "geom:longitude":15.624094,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.OW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835211,
-    "wof:geomhash":"15bc29f9d1f699e6a8636624cfd3aba0",
+    "wof:geomhash":"eda7e04145ae7aec73a21c7f11891ad9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785171,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Oshakati West",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/517/3/1108785173.geojson
+++ b/data/110/878/517/3/1108785173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021966,
-    "geom:area_square_m":259098904.084055,
+    "geom:area_square_m":259098760.021546,
     "geom:bbox":"15.886593,-17.575988,16.086255,-17.390422",
     "geom:latitude":-17.45713,
     "geom:longitude":15.988535,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OW.OS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835212,
-    "wof:geomhash":"ff3db3d31620c2ed88125f8e16db2ae5",
+    "wof:geomhash":"317abec2de134072c30c79514303c335",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108785173,
-    "wof:lastmodified":1636502200,
+    "wof:lastmodified":1695886049,
     "wof:name":"Oshikango",
     "wof:parent_id":85675231,
     "wof:placetype":"county",

--- a/data/110/878/517/5/1108785175.geojson
+++ b/data/110/878/517/5/1108785175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023618,
-    "geom:area_square_m":278226307.169387,
+    "geom:area_square_m":278226366.509563,
     "geom:bbox":"15.282282,-17.785946,15.503838,-17.613475",
     "geom:latitude":-17.690719,
     "geom:longitude":15.392467,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.OS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835213,
-    "wof:geomhash":"a7d7ca5bb33f93bc2305054dc9d955f9",
+    "wof:geomhash":"c476818cb4b2a444b23113b1948154a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108785175,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Oshikuku",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/517/9/1108785179.geojson
+++ b/data/110/878/517/9/1108785179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.357939,
-    "geom:area_square_m":4196556918.093958,
+    "geom:area_square_m":4196556951.286581,
     "geom:bbox":"15.111334,-19.208395,15.597852,-17.843254",
     "geom:latitude":-18.525954,
     "geom:longitude":15.359196,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.OT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835214,
-    "wof:geomhash":"9875b14d94931bb3872362f119cc38ea",
+    "wof:geomhash":"4c9e1c54b04a707a5dc4483cdc3964d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785179,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Otamanzi",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/518/1/1108785181.geojson
+++ b/data/110/878/518/1/1108785181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.557567,
-    "geom:area_square_m":6441812357.511428,
+    "geom:area_square_m":6441812455.242421,
     "geom:bbox":"18.522232,-21.379571,19.292173,-20.316224",
     "geom:latitude":-20.875021,
     "geom:longitude":18.982258,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OH.OJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835216,
-    "wof:geomhash":"843537716797dc342fcfec4f6dc5ec2f",
+    "wof:geomhash":"6fa2b292005def379643b77c849e7c8b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108785181,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Otjinene",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/110/878/518/3/1108785183.geojson
+++ b/data/110/878/518/3/1108785183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.643452,
-    "geom:area_square_m":18949515832.008312,
+    "geom:area_square_m":18949515401.930492,
     "geom:bbox":"19.997622,-22.000342,20.998754,-20.281781",
     "geom:latitude":-21.169813,
     "geom:longitude":20.499917,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OH.OB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835217,
-    "wof:geomhash":"f21e7fdf3f80f40b87516f99e07e76b7",
+    "wof:geomhash":"68fdc44284479888f6c3c4e5aa9db525",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785183,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886082,
     "wof:name":"Otjombinde",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/110/878/518/5/1108785185.geojson
+++ b/data/110/878/518/5/1108785185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083757,
-    "geom:area_square_m":987637853.504158,
+    "geom:area_square_m":987637853.504172,
     "geom:bbox":"14.6436777856,-17.6703874018,15.0410540716,-17.391352",
     "geom:latitude":-17.517809,
     "geom:longitude":14.846569,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835218,
-    "wof:geomhash":"6e692f61448505ffa199c62cdd9eeb08",
+    "wof:geomhash":"737db07c28a700baf851d6eafc5ce3d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108785185,
-    "wof:lastmodified":1566647632,
+    "wof:lastmodified":1695886415,
     "wof:name":"Outapi",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/518/7/1108785187.geojson
+++ b/data/110/878/518/7/1108785187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.969074,
-    "geom:area_square_m":10963872761.949915,
+    "geom:area_square_m":10963872214.034164,
     "geom:bbox":"16.305473,-24.355654,17.743992,-23.220708",
     "geom:latitude":-23.797397,
     "geom:longitude":16.9483,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"NA.HA.RR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835220,
-    "wof:geomhash":"27b201becfeb7ea3ecf41763ccb6df81",
+    "wof:geomhash":"1e4f5cc8656b8564fa9399a3abd46bbd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108785187,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886083,
     "wof:name":"Rehoboth Rural",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/110/878/518/9/1108785189.geojson
+++ b/data/110/878/518/9/1108785189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051062,
-    "geom:area_square_m":600429633.059051,
+    "geom:area_square_m":600429397.612687,
     "geom:bbox":"19.789427,-18.218321,20.003633,-17.86182",
     "geom:latitude":-18.018566,
     "geom:longitude":19.919792,
@@ -51,7 +51,7 @@
     "wof:concordances":{},
     "wof:country":"NA",
     "wof:created":1481835222,
-    "wof:geomhash":"db809f742d2fc337263125cf7122b2e9",
+    "wof:geomhash":"b7eb4e584e50c01368886b352dadd11d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":1108785189,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886083,
     "wof:name":"Rundu Rural East",
     "wof:parent_id":85675237,
     "wof:placetype":"county",

--- a/data/110/878/519/1/1108785191.geojson
+++ b/data/110/878/519/1/1108785191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178942,
-    "geom:area_square_m":2101825931.540339,
+    "geom:area_square_m":2101826195.73473,
     "geom:bbox":"19.499013,-18.565462,20.002331,-17.873687",
     "geom:latitude":-18.210284,
     "geom:longitude":19.729311,
@@ -57,7 +57,7 @@
     "wof:concordances":{},
     "wof:country":"NA",
     "wof:created":1481835223,
-    "wof:geomhash":"b21b94b3f44b97f2b71606ffb0b2ab5a",
+    "wof:geomhash":"acb1e66c111c88e20ea981fce81eea64",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1108785191,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886083,
     "wof:name":"Rundu Rural West",
     "wof:parent_id":85675237,
     "wof:placetype":"county",

--- a/data/110/878/519/3/1108785193.geojson
+++ b/data/110/878/519/3/1108785193.geojson
@@ -180,9 +180,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KH.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835226,
-    "wof:geomhash":"72bc72923151b047b3057594f7c9d1d8",
+    "wof:geomhash":"cb16138e1b40268c542112d577ccc5d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1108785193,
-    "wof:lastmodified":1566647631,
+    "wof:lastmodified":1695886415,
     "wof:name":"Soweto",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/110/878/519/7/1108785197.geojson
+++ b/data/110/878/519/7/1108785197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.527086,
-    "geom:area_square_m":17533746929.71006,
+    "geom:area_square_m":17533746929.709991,
     "geom:bbox":"17.9572419162,-22.4827421685,20.0099734992,-20.9909318417",
     "geom:latitude":-21.786228,
     "geom:longitude":18.810407,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OH.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835227,
-    "wof:geomhash":"e227a955ff2251decba9a0df0726ed42",
+    "wof:geomhash":"ac7b32221d8ae1a1e65c7addd8770666",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108785197,
-    "wof:lastmodified":1566647630,
+    "wof:lastmodified":1695886415,
     "wof:name":"Steinhausen",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/110/878/519/9/1108785199.geojson
+++ b/data/110/878/519/9/1108785199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001751,
-    "geom:area_square_m":20003371.419801,
+    "geom:area_square_m":20003371.419804,
     "geom:bbox":"17.0413480967,-22.5151496179,17.0918512943,-22.4685590123",
     "geom:latitude":-22.491409,
     "geom:longitude":17.066776,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KH.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835228,
-    "wof:geomhash":"930c6757b4a7dbb26c2dbeedcc0dd946",
+    "wof:geomhash":"463f548a4681852d08e1b180b21573b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785199,
-    "wof:lastmodified":1566647630,
+    "wof:lastmodified":1695886415,
     "wof:name":"Tobias Hainyeko",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/110/878/520/1/1108785201.geojson
+++ b/data/110/878/520/1/1108785201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.201702,
-    "geom:area_square_m":2373519850.181324,
+    "geom:area_square_m":2373520313.030918,
     "geom:bbox":"14.549065,-18.204421,15.072221,-17.636342",
     "geom:latitude":-17.887027,
     "geom:longitude":14.785939,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OS.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835229,
-    "wof:geomhash":"456e2ea63d34e319c0f27e33facc9a05",
+    "wof:geomhash":"568c97cffd135aca9bac2a27fde1d6b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108785201,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886083,
     "wof:name":"Tsandi",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/110/878/520/3/1108785203.geojson
+++ b/data/110/878/520/3/1108785203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.402365,
-    "geom:area_square_m":27962293203.785084,
+    "geom:area_square_m":27962292534.812965,
     "geom:bbox":"18.67264,-20.453051,20.998761,-18.796983",
     "geom:latitude":-19.724312,
     "geom:longitude":19.950408,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"NA.OD.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835230,
-    "wof:geomhash":"58cf1d38a90c68a5d6baa2f7581cc002",
+    "wof:geomhash":"9793caca31f927e3799a683b0ea95856",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108785203,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886083,
     "wof:name":"Tsumkwe",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/110/878/520/5/1108785205.geojson
+++ b/data/110/878/520/5/1108785205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.498146,
-    "geom:area_square_m":5835356460.492994,
+    "geom:area_square_m":5835356714.205738,
     "geom:bbox":"15.282799,-19.330408,16.025119,-17.931839",
     "geom:latitude":-18.67162,
     "geom:longitude":15.696555,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"NA.ON.UV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835232,
-    "wof:geomhash":"77e5e290eafbfbcbcb920dd0cc7823c2",
+    "wof:geomhash":"bfda0a4d35053d3a15bd13eaf75a8fd8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108785205,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886084,
     "wof:name":"Uuvudhiya",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/110/878/520/7/1108785207.geojson
+++ b/data/110/878/520/7/1108785207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001793,
-    "geom:area_square_m":20481688.169615,
+    "geom:area_square_m":20481672.955971,
     "geom:bbox":"16.985863,-22.537784,17.043903,-22.47826",
     "geom:latitude":-22.514785,
     "geom:longitude":17.01085,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"NA.KH.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1481835235,
-    "wof:geomhash":"f6735956a8598d4c7d4e81ced2cd9b42",
+    "wof:geomhash":"1c9700baf67867f3104044c9797ecf23",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108785207,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886084,
     "wof:name":"Wanaheda",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/110/880/489/9/1108804899.geojson
+++ b/data/110/880/489/9/1108804899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.191425,
-    "geom:area_square_m":25703934750.714424,
+    "geom:area_square_m":25703935407.40704,
     "geom:bbox":"19.469117,-19.184094,22.508587,-17.821976",
     "geom:latitude":-18.450689,
     "geom:longitude":20.601352,
@@ -134,12 +134,14 @@
     "wof:concordances":{
         "fips:code":"WA40",
         "hasc:id":"NA.KE",
+        "iso:code":"NA-KE",
         "iso:id":"NA-KE",
         "wd:id":"Q14824032"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:created":1485471365,
-    "wof:geomhash":"252cb2fed7b2e8f0fcca328b9cfc8f80",
+    "wof:geomhash":"ca1915f26183b39f8d2741ee7ea136a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +158,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848279,
+    "wof:lastmodified":1695884327,
     "wof:name":"Kavango East",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/110/880/490/1/1108804901.geojson
+++ b/data/110/880/490/1/1108804901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.232346,
-    "geom:area_square_m":14503645133.135628,
+    "geom:area_square_m":14503643862.465202,
     "geom:bbox":"22.495056,-18.502285,25.261752,-17.469636",
     "geom:latitude":-17.861569,
     "geom:longitude":23.846684,
@@ -230,12 +230,14 @@
     "wof:concordances":{
         "fips:code":"WA28",
         "hasc:id":"NA.CA",
+        "iso:code":"NA-CA",
         "iso:id":"NA-CA",
         "wd:id":"Q473190"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:created":1485471367,
-    "wof:geomhash":"77d2f7e83b3c17a3433e50d82261110e",
+    "wof:geomhash":"ec48cd5158eacc27882d02ed9768c5aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -252,7 +254,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848278,
+    "wof:lastmodified":1695884923,
     "wof:name":"Zambezi",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/110/880/490/3/1108804903.geojson
+++ b/data/110/880/490/3/1108804903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.979066,
-    "geom:area_square_m":23236799490.046352,
+    "geom:area_square_m":23236799490.046444,
     "geom:bbox":"17.9976726857,-19.1841241125,19.7995758376,-17.389509",
     "geom:latitude":-18.27409,
     "geom:longitude":18.80354,
@@ -173,11 +173,13 @@
         "gn:id":3371204,
         "gp:id":20069820,
         "hasc:id":"NA.KW",
+        "iso:code":"NA-KW",
         "iso:id":"NA-KW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:created":1485471369,
-    "wof:geomhash":"1becdf0137ff9e7e1d154756fe02f7ef",
+    "wof:geomhash":"8a2ca201a118a2b84d23000c8fa1bb67",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -194,7 +196,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1566647626,
+    "wof:lastmodified":1695884327,
     "wof:name":"Kavango West",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/421/166/795/421166795.geojson
+++ b/data/421/166/795/421166795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.272786,
-    "geom:area_square_m":26208197508.219078,
+    "geom:area_square_m":26208196969.082626,
     "geom:bbox":"16.11679,-22.261585,18.396728,-20.115866",
     "geom:latitude":-21.157351,
     "geom:longitude":17.268517,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.OD.OM",
         "qs_pg:id":1247382
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459008702,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4f10329249754eb2171dc35f44acca75",
+    "wof:geomhash":"8ed8a379f703d23d7b78930d2a9b270b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421166795,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886080,
     "wof:name":"Omatako",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/170/191/421170191.geojson
+++ b/data/421/170/191/421170191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.502912,
-    "geom:area_square_m":50571243199.244606,
+    "geom:area_square_m":50571243199.245537,
     "geom:bbox":"14.451167107,-25.8621141526,18.4798619612,-23.5452705234",
     "geom:latitude":-24.728955,
     "geom:longitude":16.206895,
@@ -103,12 +103,13 @@
         "hasc:id":"NA.HA.GB",
         "qs_pg:id":225218
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459008842,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f3287e048c887be07a74480a3b431a24",
+    "wof:geomhash":"b2c3c2ad4eef20173011da72ec1df58c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":421170191,
-    "wof:lastmodified":1582351967,
+    "wof:lastmodified":1695886800,
     "wof:name":"Gibeon",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/170/307/421170307.geojson
+++ b/data/421/170/307/421170307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.994795,
-    "geom:area_square_m":23514109352.824631,
+    "geom:area_square_m":23514110197.07288,
     "geom:bbox":"11.734472,-18.010525,14.280082,-16.963485",
     "geom:latitude":-17.577569,
     "geom:longitude":12.951056,
@@ -88,12 +88,13 @@
         "hasc:id":"NA.KU.EP",
         "qs_pg:id":238045
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459008847,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c49ca245f1ccba9276e9c7498587486d",
+    "wof:geomhash":"32691667fbccbac128f70e53ed6e69c6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421170307,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886074,
     "wof:name":"Epupa",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/171/383/421171383.geojson
+++ b/data/421/171/383/421171383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002308,
-    "geom:area_square_m":26360823.544221,
+    "geom:area_square_m":26360790.206389,
     "geom:bbox":"16.981472,-22.565225,17.071601,-22.521353",
     "geom:latitude":-22.546575,
     "geom:longitude":17.023244,
@@ -107,12 +107,13 @@
         "qs_pg:id":1247385,
         "wd:id":"Q15237923"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459008891,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"44e32eb21e55908ba9ba7b065fc05c7a",
+    "wof:geomhash":"eeb5125749ca691a5ac6f6dbab89085c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421171383,
-    "wof:lastmodified":1690848293,
+    "wof:lastmodified":1695886076,
     "wof:name":"Khomasdal North",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/172/943/421172943.geojson
+++ b/data/421/172/943/421172943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.458758,
-    "geom:area_square_m":5391785882.114957,
+    "geom:area_square_m":5391786268.518581,
     "geom:bbox":"14.133023,-19.011047,14.655109,-17.391579",
     "geom:latitude":-18.099304,
     "geom:longitude":14.407417,
@@ -136,12 +136,13 @@
         "qs_pg:id":486720,
         "wd:id":"Q1013946"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459008960,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb105a5ec8dd8c9f27cc6df268120b69",
+    "wof:geomhash":"3dee3bac275108e6039215786177314f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421172943,
-    "wof:lastmodified":1690848286,
+    "wof:lastmodified":1695886800,
     "wof:name":"Ruacana",
     "wof:parent_id":85675223,
     "wof:placetype":"county",

--- a/data/421/175/605/421175605.geojson
+++ b/data/421/175/605/421175605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018263,
-    "geom:area_square_m":208457267.161093,
+    "geom:area_square_m":208457558.691275,
     "geom:bbox":"14.502833,-22.689954,14.719028,-22.56695",
     "geom:latitude":-22.619703,
     "geom:longitude":14.599047,
@@ -198,12 +198,13 @@
         "hasc:id":"NA.ER.SW",
         "qs_pg:id":383386
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1bb199fb3bc2a912dfeb8e27108e652",
+    "wof:geomhash":"db52842fa06ab8fd4f1d85714064bcf6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":421175605,
-    "wof:lastmodified":1636502203,
+    "wof:lastmodified":1695886050,
     "wof:name":"Swakopmund",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/175/607/421175607.geojson
+++ b/data/421/175/607/421175607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.072905,
-    "geom:area_square_m":12256332869.712692,
+    "geom:area_square_m":12256332854.513306,
     "geom:bbox":"18.801906,-23.109533,20.00292,-21.947907",
     "geom:latitude":-22.503344,
     "geom:longitude":19.483245,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.OH.KA",
         "qs_pg:id":383387
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"54159f9d18dc41ba8807470bb9e8a19c",
+    "wof:geomhash":"6f4e25e92cacb9bdc13c77c882dd2839",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421175607,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886075,
     "wof:name":"Kalahari",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/421/175/609/421175609.geojson
+++ b/data/421/175/609/421175609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.424787,
-    "geom:area_square_m":5001053443.199582,
+    "geom:area_square_m":5001053725.070045,
     "geom:bbox":"22.495056,-18.116006,24.218228,-17.487784",
     "geom:latitude":-17.802164,
     "geom:longitude":23.262902,
@@ -107,12 +107,13 @@
         "qs_pg:id":383388,
         "wd:id":"Q1781540"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59890e150c0d356ce6b769a318b3318b",
+    "wof:geomhash":"91cfc0d682f9fd4764ad36349e80e99f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421175609,
-    "wof:lastmodified":1690848288,
+    "wof:lastmodified":1695886800,
     "wof:name":"Kongola",
     "wof:parent_id":1108804901,
     "wof:placetype":"county",

--- a/data/421/175/611/421175611.geojson
+++ b/data/421/175/611/421175611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.547786,
-    "geom:area_square_m":17821831452.817493,
+    "geom:area_square_m":17821831487.971073,
     "geom:bbox":"13.94035,-22.227092,15.708679,-20.490081",
     "geom:latitude":-21.375046,
     "geom:longitude":14.93772,
@@ -99,12 +99,13 @@
         "hasc:id":"NA.ER.DA",
         "qs_pg:id":383398
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"769f9db49dab74b89bc6fe39089501f9",
+    "wof:geomhash":"114cccc8c61004da89fe1d5aef3559f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":421175611,
-    "wof:lastmodified":1627522456,
+    "wof:lastmodified":1695886072,
     "wof:name":"Daures",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/175/613/421175613.geojson
+++ b/data/421/175/613/421175613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.644459,
-    "geom:area_square_m":7496481756.836885,
+    "geom:area_square_m":7496481452.567667,
     "geom:bbox":"15.895038,-20.43419,16.722063,-19.32887",
     "geom:latitude":-19.825193,
     "geom:longitude":16.273927,
@@ -159,12 +159,13 @@
         "hasc:id":"NA.KU.OU",
         "qs_pg:id":383399
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e2910fa979f599adad8addd148cec123",
+    "wof:geomhash":"750ee7ea9b42fc2af64ce1a549d0f281",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421175613,
-    "wof:lastmodified":1636502204,
+    "wof:lastmodified":1695886051,
     "wof:name":"Outjo",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/175/615/421175615.geojson
+++ b/data/421/175/615/421175615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.185418,
-    "geom:area_square_m":13564470548.904703,
+    "geom:area_square_m":13564470441.591085,
     "geom:bbox":"13.631185,-23.330091,15.811557,-21.012075",
     "geom:latitude":-22.263169,
     "geom:longitude":14.689479,
@@ -91,12 +91,13 @@
         "hasc:id":"NA.ER.AR",
         "qs_pg:id":383400
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e4d84d4b9620d34a04643bc07c767225",
+    "wof:geomhash":"d332168e9a230a4076f870d6e406d266",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421175615,
-    "wof:lastmodified":1627522456,
+    "wof:lastmodified":1695886073,
     "wof:name":"Arandis",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/175/621/421175621.geojson
+++ b/data/421/175/621/421175621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.873439,
-    "geom:area_square_m":31822525614.62524,
+    "geom:area_square_m":31822524548.480381,
     "geom:bbox":"16.403416,-27.985395,18.680711,-25.436331",
     "geom:latitude":-26.403339,
     "geom:longitude":17.43135,
@@ -101,12 +101,13 @@
         "qs_pg:id":383402,
         "wd:id":"Q2713629"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b18365e913947714af7552bd14501579",
+    "wof:geomhash":"cbdcdf2198a454733aae07e4555a5191",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":421175621,
-    "wof:lastmodified":1690848288,
+    "wof:lastmodified":1695886800,
     "wof:name":"Berseba",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/179/905/421179905.geojson
+++ b/data/421/179/905/421179905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023937,
-    "geom:area_square_m":279466650.259218,
+    "geom:area_square_m":279466636.537196,
     "geom:bbox":"17.606979,-19.304061,17.835707,-19.173187",
     "geom:latitude":-19.233254,
     "geom:longitude":17.718434,
@@ -200,12 +200,13 @@
         "qs_pg:id":476082,
         "wd:id":"Q639467"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009237,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d004070918d9fbad2d2cbec96bbb56a0",
+    "wof:geomhash":"b63528900b6c97efd2726d5f9db6efe4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":421179905,
-    "wof:lastmodified":1690848291,
+    "wof:lastmodified":1695886051,
     "wof:name":"Tsumeb",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/421/183/083/421183083.geojson
+++ b/data/421/183/083/421183083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025339,
-    "geom:area_square_m":287760012.509347,
+    "geom:area_square_m":287760100.864198,
     "geom:bbox":"17.072392,-23.443568,17.216344,-23.167949",
     "geom:latitude":-23.304579,
     "geom:longitude":17.141795,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.HA.RE",
         "qs_pg:id":961486
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009357,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e676f58848ad5bd240bee6d0735cd0d0",
+    "wof:geomhash":"44879eaa75a03d2ea1a52b10a3318cd6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421183083,
-    "wof:lastmodified":1627522461,
+    "wof:lastmodified":1695886081,
     "wof:name":"Rehoboth East",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/183/085/421183085.geojson
+++ b/data/421/183/085/421183085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025496,
-    "geom:area_square_m":299839308.299387,
+    "geom:area_square_m":299839350.553502,
     "geom:bbox":"15.763042,-18.067899,16.001003,-17.93292",
     "geom:latitude":-17.9962,
     "geom:longitude":15.884172,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.ON.UK",
         "qs_pg:id":961487
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009357,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d9e139f66e09762508ee11ed174cc75",
+    "wof:geomhash":"2ae7b034cb4307eae07653983a76acc1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421183085,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886083,
     "wof:name":"Uukwiyu",
     "wof:parent_id":85675227,
     "wof:placetype":"county",

--- a/data/421/183/951/421183951.geojson
+++ b/data/421/183/951/421183951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.874558,
-    "geom:area_square_m":10231345789.695444,
+    "geom:area_square_m":10231345678.58667,
     "geom:bbox":"17.027066,-19.532283,18.199862,-18.386498",
     "geom:latitude":-18.893097,
     "geom:longitude":17.593723,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.OT.GN",
         "qs_pg:id":986717
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009396,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2e16df334af891f1e5e08495a9b8a458",
+    "wof:geomhash":"96229b1da9aebf4b99e7bf60a7180388",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421183951,
-    "wof:lastmodified":1627522457,
+    "wof:lastmodified":1695886075,
     "wof:name":"Guinas",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/421/186/163/421186163.geojson
+++ b/data/421/186/163/421186163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.513012,
-    "geom:area_square_m":5941567289.114032,
+    "geom:area_square_m":5941567502.169897,
     "geom:bbox":"15.575227,-21.013652,16.90681,-19.971519",
     "geom:latitude":-20.504065,
     "geom:longitude":16.25362,
@@ -162,12 +162,13 @@
         "hasc:id":"NA.OD.OW",
         "qs_pg:id":1090160
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009472,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81fae40bad7b15fa47235f6358940051",
+    "wof:geomhash":"f35722740c66097fe49ca2870953de4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":421186163,
-    "wof:lastmodified":1636502203,
+    "wof:lastmodified":1695886050,
     "wof:name":"Otjiwarongo",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/186/171/421186171.geojson
+++ b/data/421/186/171/421186171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.968186,
-    "geom:area_square_m":11298311402.342165,
+    "geom:area_square_m":11298310945.704063,
     "geom:bbox":"17.835028,-20.040511,19.028655,-18.748265",
     "geom:latitude":-19.307659,
     "geom:longitude":18.43566,
@@ -168,12 +168,13 @@
         "hasc:id":"NA.OD.GR",
         "qs_pg:id":1090161
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009472,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e96fa77fa5c5ce29e62b151c63204f20",
+    "wof:geomhash":"783da443cff9b3ce66721d20301a2ba2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421186171,
-    "wof:lastmodified":1636502203,
+    "wof:lastmodified":1695886050,
     "wof:name":"Grootfontein",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/186/173/421186173.geojson
+++ b/data/421/186/173/421186173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.274528,
-    "geom:area_square_m":14580311164.701918,
+    "geom:area_square_m":14580311696.298752,
     "geom:bbox":"14.911143,-23.259177,16.465238,-21.573017",
     "geom:latitude":-22.304922,
     "geom:longitude":15.786858,
@@ -176,12 +176,13 @@
         "qs_pg:id":1090162,
         "wd:id":"Q1348181"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009472,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa28f5bd276757cb184c251e39dad9ec",
+    "wof:geomhash":"f8eb5b8ac84b872f90c32d76da699bde",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421186173,
-    "wof:lastmodified":1690848286,
+    "wof:lastmodified":1695886050,
     "wof:name":"Karibib",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/186/215/421186215.geojson
+++ b/data/421/186/215/421186215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.215018,
-    "geom:area_square_m":36614208018.844994,
+    "geom:area_square_m":36614209148.79541,
     "geom:bbox":"15.728849,-24.077511,18.498395,-21.708806",
     "geom:latitude":-22.920669,
     "geom:longitude":17.154163,
@@ -113,12 +113,13 @@
         "qs_pg:id":1090163,
         "wd:id":"Q904970"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009474,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1212f1f0f339cebc780127f7c10e5ee",
+    "wof:geomhash":"69169d4295a60e4199842d138edbf837",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421186215,
-    "wof:lastmodified":1690848286,
+    "wof:lastmodified":1695886084,
     "wof:name":"Windhoek Rural",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/186/223/421186223.geojson
+++ b/data/421/186/223/421186223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.719265,
-    "geom:area_square_m":41827486893.384605,
+    "geom:area_square_m":41827486886.524345,
     "geom:bbox":"17.457824,-25.67044,19.999318,-23.476004",
     "geom:latitude":-24.557923,
     "geom:longitude":18.932387,
@@ -110,12 +110,13 @@
         "qs_pg:id":1090164,
         "wd:id":"Q1897980"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009474,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5056d459382efc10477a442fcf72842f",
+    "wof:geomhash":"cb309c41c09aa0d450073dcd2b2bbc77",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421186223,
-    "wof:lastmodified":1690848287,
+    "wof:lastmodified":1695886077,
     "wof:name":"Mariental Rural",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/186/267/421186267.geojson
+++ b/data/421/186/267/421186267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.733618,
-    "geom:area_square_m":8450594551.782156,
+    "geom:area_square_m":8450594729.376764,
     "geom:bbox":"15.417669,-21.763038,16.553924,-20.672798",
     "geom:latitude":-21.317598,
     "geom:longitude":15.95859,
@@ -133,12 +133,13 @@
         "hasc:id":"NA.ER.OM",
         "qs_pg:id":1090167
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009475,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c136afdf3a5ba2448c1e64ea10e848fb",
+    "wof:geomhash":"0ada31de674ef2ade8c98f7aef2a0ff2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421186267,
-    "wof:lastmodified":1636502202,
+    "wof:lastmodified":1695886049,
     "wof:name":"Omaruru",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/186/335/421186335.geojson
+++ b/data/421/186/335/421186335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.147391,
-    "geom:area_square_m":13422694255.915821,
+    "geom:area_square_m":13422693691.853992,
     "geom:bbox":"15.841179,-19.487205,17.161779,-18.157482",
     "geom:latitude":-18.898974,
     "geom:longitude":16.510297,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.OT.OG",
         "qs_pg:id":1090169
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009477,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e4ebbbed92b2dd1ab4bfbf5107289c3",
+    "wof:geomhash":"146c45293c253c7d510672e147280634",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421186335,
-    "wof:lastmodified":1627522460,
+    "wof:lastmodified":1695886080,
     "wof:name":"Omuthiyagwipundi",
     "wof:parent_id":85675243,
     "wof:placetype":"county",

--- a/data/421/186/343/421186343.geojson
+++ b/data/421/186/343/421186343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.197872,
-    "geom:area_square_m":25775945731.399246,
+    "geom:area_square_m":25775944859.184544,
     "geom:bbox":"11.816222,-19.017947,14.392226,-17.997757",
     "geom:latitude":-18.476303,
     "geom:longitude":13.208568,
@@ -229,12 +229,13 @@
         "qs_pg:id":1090171,
         "wd:id":"Q1024089"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009478,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e2c5dd6227dc7b656624563f49af47c7",
+    "wof:geomhash":"e00a70e7411244fa8fa2231de290b9ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +245,7 @@
         }
     ],
     "wof:id":421186343,
-    "wof:lastmodified":1690848287,
+    "wof:lastmodified":1695886050,
     "wof:name":"Opuwo",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/186/345/421186345.geojson
+++ b/data/421/186/345/421186345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019042,
-    "geom:area_square_m":217356413.996648,
+    "geom:area_square_m":217356433.376258,
     "geom:bbox":"16.872763,-22.689271,17.088574,-22.535427",
     "geom:latitude":-22.613829,
     "geom:longitude":16.99736,
@@ -101,12 +101,13 @@
         "qs_pg:id":1090170,
         "wd:id":"Q527453"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009478,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c5c9e93d4a5a2938a218759872c0e9b",
+    "wof:geomhash":"546f9e2185a3c8cc4968c6deecfdc326",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":421186345,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886084,
     "wof:name":"Windhoek West",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/186/355/421186355.geojson
+++ b/data/421/186/355/421186355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.117465,
-    "geom:area_square_m":12999033052.356361,
+    "geom:area_square_m":12999033451.611631,
     "geom:bbox":"16.699359,-20.392319,18.163501,-19.140426",
     "geom:latitude":-19.819559,
     "geom:longitude":17.363348,
@@ -153,12 +153,13 @@
         "hasc:id":"NA.OD.OV",
         "qs_pg:id":1090172
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009478,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"19d8c9c95d5674937db1019620b8e26b",
+    "wof:geomhash":"d03cecae994cac5dfbb5f5df1fa65bfa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421186355,
-    "wof:lastmodified":1636502202,
+    "wof:lastmodified":1695886049,
     "wof:name":"Otavi",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/186/541/421186541.geojson
+++ b/data/421/186/541/421186541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.470475,
-    "geom:area_square_m":5529836026.023568,
+    "geom:area_square_m":5529835871.955321,
     "geom:bbox":"20.996724,-18.317336,22.508587,-17.821976",
     "geom:latitude":-18.093695,
     "geom:longitude":21.71938,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.KE.MU",
         "qs_pg:id":1073327
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009484,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be1a9b8d6cd249dd676341189be61b1d",
+    "wof:geomhash":"8873e4554903e66dba4504df8bc032ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421186541,
-    "wof:lastmodified":1627522459,
+    "wof:lastmodified":1695886078,
     "wof:name":"Mukwe",
     "wof:parent_id":1108804899,
     "wof:placetype":"county",

--- a/data/421/190/657/421190657.geojson
+++ b/data/421/190/657/421190657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.392809,
-    "geom:area_square_m":4286157693.115278,
+    "geom:area_square_m":4286158200.173295,
     "geom:bbox":"16.177916,-28.63213,17.452433,-27.549925",
     "geom:latitude":-28.060517,
     "geom:longitude":16.864521,
@@ -162,12 +162,13 @@
         "hasc:id":"NA.KA.OR",
         "qs_pg:id":1119977
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009664,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"daa2317c1a916fc69142db57698aa0d2",
+    "wof:geomhash":"4e515a8974a5b8a7809e3302ae258beb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":421190657,
-    "wof:lastmodified":1636502204,
+    "wof:lastmodified":1695886051,
     "wof:name":"Oranjemund",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/190/659/421190659.geojson
+++ b/data/421/190/659/421190659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.808556,
-    "geom:area_square_m":9182001166.122431,
+    "geom:area_square_m":9182002414.799484,
     "geom:bbox":"14.402805,-23.809994,15.847985,-22.645237",
     "geom:latitude":-23.307169,
     "geom:longitude":15.042577,
@@ -113,12 +113,13 @@
         "qs_pg:id":1119980,
         "wd:id":"Q1800633"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009664,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"22a69cbea66b8817ce460cb629619e32",
+    "wof:geomhash":"6cf1cb75036a4fae2df61e229de43d30",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421190659,
-    "wof:lastmodified":1690848289,
+    "wof:lastmodified":1695886800,
     "wof:name":"Walvisbay Rural",
     "wof:parent_id":85675213,
     "wof:placetype":"county",

--- a/data/421/191/505/421191505.geojson
+++ b/data/421/191/505/421191505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015437,
-    "geom:area_square_m":176193122.553298,
+    "geom:area_square_m":176193091.242537,
     "geom:bbox":"17.066794,-22.706928,17.233346,-22.549157",
     "geom:latitude":-22.619869,
     "geom:longitude":17.144816,
@@ -110,12 +110,13 @@
         "qs_pg:id":1137623,
         "wd:id":"Q656427"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009695,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8746872352692ad9a2ef87de685065cb",
+    "wof:geomhash":"9f3f5bf0680572a91f25dbc55366673a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421191505,
-    "wof:lastmodified":1690848289,
+    "wof:lastmodified":1695886083,
     "wof:name":"Windhoek East",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/195/837/421195837.geojson
+++ b/data/421/195/837/421195837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029444,
-    "geom:area_square_m":334404320.067985,
+    "geom:area_square_m":334404188.757702,
     "geom:bbox":"16.937911,-23.443568,17.117175,-23.166843",
     "geom:latitude":-23.291727,
     "geom:longitude":17.035019,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.HA.RW",
         "qs_pg:id":127925
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009860,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be7c4aff686a12aff64ae9f23d022743",
+    "wof:geomhash":"a49ca7d7c2c701a982787059d3f2ac5f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421195837,
-    "wof:lastmodified":1627522462,
+    "wof:lastmodified":1695886083,
     "wof:name":"Rehoboth West",
     "wof:parent_id":85675199,
     "wof:placetype":"county",

--- a/data/421/199/731/421199731.geojson
+++ b/data/421/199/731/421199731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142664,
-    "geom:area_square_m":1679068313.748498,
+    "geom:area_square_m":1679068191.364892,
     "geom:bbox":"23.819333,-18.116301,24.347361,-17.606351",
     "geom:latitude":-17.858193,
     "geom:longitude":24.108096,
@@ -104,12 +104,13 @@
         "qs_pg:id":486728,
         "wd:id":"Q2280865"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459009999,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bba1240d2ded0b867c5e05046f4b338a",
+    "wof:geomhash":"04a53615ac0a8e10183767333cfb490f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421199731,
-    "wof:lastmodified":1690848289,
+    "wof:lastmodified":1695886800,
     "wof:name":"Sibinda",
     "wof:parent_id":1108804901,
     "wof:placetype":"county",

--- a/data/421/199/941/421199941.geojson
+++ b/data/421/199/941/421199941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162371,
-    "geom:area_square_m":1911812171.329673,
+    "geom:area_square_m":1911811636.786396,
     "geom:bbox":"24.182994,-18.073896,24.770924,-17.474406",
     "geom:latitude":-17.782714,
     "geom:longitude":24.454178,
@@ -110,12 +110,13 @@
         "qs_pg:id":18130,
         "wd:id":"Q3813969"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010005,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dcacff5858fa34f8a4ddc7535bc8df1d",
+    "wof:geomhash":"558a778cfd52f6d44ee142637676f5a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421199941,
-    "wof:lastmodified":1690848290,
+    "wof:lastmodified":1695886800,
     "wof:name":"Katima Muliro Rural",
     "wof:parent_id":1108804901,
     "wof:placetype":"county",

--- a/data/421/200/829/421200829.geojson
+++ b/data/421/200/829/421200829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.403677,
-    "geom:area_square_m":48658761387.742142,
+    "geom:area_square_m":48658759818.607544,
     "geom:bbox":"14.798722,-28.397514,17.01145,-25.009443",
     "geom:latitude":-26.657439,
     "geom:longitude":15.870281,
@@ -87,12 +87,13 @@
         "hasc:id":"NA.KA.LU",
         "qs_pg:id":897418
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010043,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da883d12bdd1d8dcffd22532ff082bd9",
+    "wof:geomhash":"093f8a220772bbb8d42deba6803360fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421200829,
-    "wof:lastmodified":1627522458,
+    "wof:lastmodified":1695886077,
     "wof:name":"Luderitz",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/201/547/421201547.geojson
+++ b/data/421/201/547/421201547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001718,
-    "geom:area_square_m":20217730.761281,
+    "geom:area_square_m":20217764.456016,
     "geom:bbox":"19.727783,-17.924809,19.799576,-17.875941",
     "geom:latitude":-17.906928,
     "geom:longitude":19.770353,
@@ -104,12 +104,13 @@
         "qs_pg:id":212588,
         "wd:id":"Q3942709"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010076,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b25363bfb1b1ea61e3d0a90de85b910f",
+    "wof:geomhash":"cae81b0643dfd0f13f376d72769eb7f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421201547,
-    "wof:lastmodified":1690848290,
+    "wof:lastmodified":1695886083,
     "wof:name":"Rundu Urban",
     "wof:parent_id":1108804903,
     "wof:placetype":"county",

--- a/data/421/201/549/421201549.geojson
+++ b/data/421/201/549/421201549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.499914,
-    "geom:area_square_m":5701828281.467148,
+    "geom:area_square_m":5701828464.683895,
     "geom:bbox":"18.108542,-23.180263,19.07189,-22.349861",
     "geom:latitude":-22.720167,
     "geom:longitude":18.601283,
@@ -159,12 +159,13 @@
         "hasc:id":"NA.OH.GO",
         "qs_pg:id":212589
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010076,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f0fe0217f9f69490ec85c2cc5407f7f",
+    "wof:geomhash":"dc18b3fa27afe8d88e53b7a446b7e349",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421201549,
-    "wof:lastmodified":1636502204,
+    "wof:lastmodified":1695886051,
     "wof:name":"Gobabis",
     "wof:parent_id":85675235,
     "wof:placetype":"county",

--- a/data/421/201/551/421201551.geojson
+++ b/data/421/201/551/421201551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.515338,
-    "geom:area_square_m":5914962876.624782,
+    "geom:area_square_m":5914962515.803857,
     "geom:bbox":"16.332519,-22.378546,17.025215,-21.178878",
     "geom:latitude":-21.836316,
     "geom:longitude":16.669448,
@@ -236,12 +236,13 @@
         "qs_pg:id":212590,
         "wd:id":"Q597491"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010076,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0c7560769120efbea312ff8c92655180",
+    "wof:geomhash":"31ac6c84e3a2fabc48b08bb704a7dc16",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -251,7 +252,7 @@
         }
     ],
     "wof:id":421201551,
-    "wof:lastmodified":1690848290,
+    "wof:lastmodified":1695886051,
     "wof:name":"Okahandja",
     "wof:parent_id":85675217,
     "wof:placetype":"county",

--- a/data/421/202/645/421202645.geojson
+++ b/data/421/202/645/421202645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.844425,
-    "geom:area_square_m":21363308840.330627,
+    "geom:area_square_m":21363308840.330574,
     "geom:bbox":"13.037055969,-21.1884565325,15.3867129381,-19.9978008354",
     "geom:latitude":-20.491403,
     "geom:longitude":14.180769,
@@ -120,12 +120,13 @@
         "hasc:id":"NA.KU.KH",
         "qs_pg:id":225210
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010125,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2a3bd60a69bdd97a67aeb56efa39252b",
+    "wof:geomhash":"99d11de930c77a952d313ff15944cd31",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421202645,
-    "wof:lastmodified":1582351961,
+    "wof:lastmodified":1695886800,
     "wof:name":"Khorixas",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/203/277/421203277.geojson
+++ b/data/421/203/277/421203277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049101,
-    "geom:area_square_m":543245770.390919,
+    "geom:area_square_m":543245405.8403,
     "geom:bbox":"18.004532,-26.685463,18.260413,-26.327776",
     "geom:latitude":-26.523618,
     "geom:longitude":18.138532,
@@ -113,12 +113,13 @@
         "qs_pg:id":230846,
         "wd:id":"Q3814256"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010146,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"84d097e7be06f8e6b2866f3b29589397",
+    "wof:geomhash":"51522b122ee9580eaeec482653f0fb3e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421203277,
-    "wof:lastmodified":1690848282,
+    "wof:lastmodified":1695886800,
     "wof:name":"Keetmanshoop Urban",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/421/203/599/421203599.geojson
+++ b/data/421/203/599/421203599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00023,
-    "geom:area_square_m":2622710.078093,
+    "geom:area_square_m":2622760.435579,
     "geom:bbox":"17.054191,-22.532999,17.074298,-22.511524",
     "geom:latitude":-22.520497,
     "geom:longitude":17.063802,
@@ -110,12 +110,13 @@
         "qs_pg:id":233878,
         "wd:id":"Q1544088"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010157,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6582b64ff75d4f18982ecf28e09ca4b8",
+    "wof:geomhash":"bf756bf7e3fcd652398f889dd5f18726",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421203599,
-    "wof:lastmodified":1690848282,
+    "wof:lastmodified":1695886077,
     "wof:name":"Katutura East",
     "wof:parent_id":85675205,
     "wof:placetype":"county",

--- a/data/421/204/099/421204099.geojson
+++ b/data/421/204/099/421204099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.733106,
-    "geom:area_square_m":20201647198.089714,
+    "geom:area_square_m":20201646261.594128,
     "geom:bbox":"12.484555,-20.003447,14.75746,-18.998803",
     "geom:latitude":-19.492673,
     "geom:longitude":13.642684,
@@ -110,12 +110,13 @@
         "qs_pg:id":238041,
         "wd:id":"Q545466"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010173,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eabd9c44fbf506a61ac546b3f19fc11b",
+    "wof:geomhash":"3155fc599ac68db0539ceef8a5f62e99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421204099,
-    "wof:lastmodified":1690848282,
+    "wof:lastmodified":1695886799,
     "wof:name":"Sesfontein",
     "wof:parent_id":85675209,
     "wof:placetype":"county",

--- a/data/421/204/103/421204103.geojson
+++ b/data/421/204/103/421204103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.431695,
-    "geom:area_square_m":37943293212.630356,
+    "geom:area_square_m":37943294187.890656,
     "geom:bbox":"17.596937,-27.661383,19.999345,-25.482986",
     "geom:latitude":-26.591841,
     "geom:longitude":18.963024,
@@ -116,12 +116,13 @@
         "qs_pg:id":238043,
         "wd:id":"Q477439"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1459010174,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"866e3a5d1107362a52a9a80fe40ea9b9",
+    "wof:geomhash":"a75496e724f4f79133bea96413c450fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421204103,
-    "wof:lastmodified":1690848282,
+    "wof:lastmodified":1695886799,
     "wof:name":"Keetmanshoop Rural",
     "wof:parent_id":85675195,
     "wof:placetype":"county",

--- a/data/856/325/35/85632535.geojson
+++ b/data/856/325/35/85632535.geojson
@@ -1143,6 +1143,7 @@
         "hasc:id":"NA",
         "icao:code":"V5",
         "ioc:id":"NAM",
+        "iso:code":"NA",
         "itu:id":"NMB",
         "loc:id":"n79039884",
         "m49:code":"516",
@@ -1157,6 +1158,7 @@
         "wk:page":"Namibia",
         "wmo:id":"NM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:country_alpha3":"NAM",
     "wof:geom_alt":[
@@ -1180,7 +1182,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1694639547,
+    "wof:lastmodified":1695881205,
     "wof:name":"Namibia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/751/95/85675195.geojson
+++ b/data/856/751/95/85675195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.665682,
-    "geom:area_square_m":161595284072.398834,
+    "geom:area_square_m":161595282488.597626,
     "geom:bbox":"14.798722,-28.970639,19.999345,-25.009443",
     "geom:latitude":-26.973659,
     "geom:longitude":17.615317,
@@ -317,17 +317,19 @@
         "gn:id":3371201,
         "gp:id":20069838,
         "hasc:id":"NA.KA",
+        "iso:code":"NA-KA",
         "iso:id":"NA-KA",
         "qs_pg:id":336933,
         "unlc:id":"NA-KA",
         "wd:id":"Q573467",
         "wk:page":"\u01c1Karas Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be45920411dac364d976f8bfa9b0c96b",
+    "wof:geomhash":"ad0a873bf21318314a87b97b62f09773",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -344,7 +346,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848277,
+    "wof:lastmodified":1695884923,
     "wof:name":"Karas",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/751/99/85675199.geojson
+++ b/data/856/751/99/85675199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.774972,
-    "geom:area_square_m":109935958480.497986,
+    "geom:area_square_m":109935958120.65657,
     "geom:bbox":"14.451167,-25.862114,19.999318,-23.166843",
     "geom:latitude":-24.551461,
     "geom:longitude":17.395145,
@@ -308,17 +308,19 @@
         "gn:id":3371200,
         "gp:id":20069844,
         "hasc:id":"NA.HA",
+        "iso:code":"NA-HA",
         "iso:id":"NA-HA",
         "qs_pg:id":338306,
         "unlc:id":"NA-HA",
         "wd:id":"Q752676",
         "wk:page":"Hardap Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f52f8a429a16d34b129cff1e33006f5e",
+    "wof:geomhash":"1584db8311452f9b9cfeffc25c010fb5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +337,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848278,
+    "wof:lastmodified":1695884923,
     "wof:name":"Hardap",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/05/85675205.geojson
+++ b/data/856/752/05/85675205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.259119,
-    "geom:area_square_m":37117685519.53788,
+    "geom:area_square_m":37117686686.158966,
     "geom:bbox":"15.728849,-24.077511,18.498395,-21.708806",
     "geom:latitude":-22.916219,
     "geom:longitude":17.152859,
@@ -304,17 +304,19 @@
         "gn:id":3352137,
         "gp:id":20069845,
         "hasc:id":"NA.KH",
+        "iso:code":"NA-KH",
         "iso:id":"NA-KH",
         "qs_pg:id":890195,
         "unlc:id":"NA-KH",
         "wd:id":"Q834508",
         "wk:page":"Khomas Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d270ebc0644e716396db1ef28f672b1",
+    "wof:geomhash":"c4639861a549a3279dba763f591f066d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848273,
+    "wof:lastmodified":1695884922,
     "wof:name":"Khomas",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/09/85675209.geojson
+++ b/data/856/752/09/85675209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.888861,
-    "geom:area_square_m":115502043053.875229,
+    "geom:area_square_m":115502042177.840012,
     "geom:bbox":"11.734472,-21.188457,16.722063,-16.963485",
     "geom:latitude":-19.134633,
     "geom:longitude":13.92924,
@@ -302,17 +302,19 @@
         "gn:id":3371202,
         "gp:id":20069839,
         "hasc:id":"NA.KU",
+        "iso:code":"NA-KU",
         "iso:id":"NA-KU",
         "qs_pg:id":236574,
         "unlc:id":"NA-KU",
         "wd:id":"Q834513",
         "wk:page":"Kunene Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c2c20320e2487e437f3903b7adb8175",
+    "wof:geomhash":"8a233f483ab06bb6cf8280eb5edfe96f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848274,
+    "wof:lastmodified":1695884922,
     "wof:name":"Kunene",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/13/85675213.geojson
+++ b/data/856/752/13/85675213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.570442,
-    "geom:area_square_m":63833537614.37056,
+    "geom:area_square_m":63833539665.759933,
     "geom:bbox":"13.631185,-23.809994,16.553924,-20.490081",
     "geom:latitude":-22.054409,
     "geom:longitude":15.227561,
@@ -308,17 +308,19 @@
         "gn:id":3371199,
         "gp:id":20069837,
         "hasc:id":"NA.ER",
+        "iso:code":"NA-ER",
         "iso:id":"NA-ER",
         "qs_pg:id":292253,
         "unlc:id":"NA-ER",
         "wd:id":"Q648753",
         "wk:page":"Erongo Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"289cc34366b3261c8d2ce0746ee51f4c",
+    "wof:geomhash":"32c8afcf5f44dfbfb89195aafca7ddbf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +337,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848276,
+    "wof:lastmodified":1695884923,
     "wof:name":"Erongo",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/17/85675217.geojson
+++ b/data/856/752/17/85675217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.055067,
-    "geom:area_square_m":104996843822.548889,
+    "geom:area_square_m":104996842675.9814,
     "geom:bbox":"15.575227,-22.378546,20.998761,-18.748265",
     "geom:latitude":-20.308292,
     "geom:longitude":18.174171,
@@ -303,17 +303,19 @@
         "gn:id":3371209,
         "gp:id":20069835,
         "hasc:id":"NA.OD",
+        "iso:code":"NA-OD",
         "iso:id":"NA-OD",
         "qs_pg:id":892647,
         "unlc:id":"NA-OD",
         "wd:id":"Q876506",
         "wk:page":"Otjozondjupa Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"70e3b3af8fc5fe0f9944e12dfd7a03ce",
+    "wof:geomhash":"1b340508e96b70ab443a959d35d580f6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848274,
+    "wof:lastmodified":1695884922,
     "wof:name":"Otjozondjupa",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/23/85675223.geojson
+++ b/data/856/752/23/85675223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.272908,
-    "geom:area_square_m":26685442736.947701,
+    "geom:area_square_m":26685442850.422134,
     "geom:bbox":"14.133023,-19.420379,15.654573,-17.390717",
     "geom:latitude":-18.280136,
     "geom:longitude":14.894838,
@@ -299,17 +299,19 @@
         "gn:id":3371206,
         "gp:id":20069842,
         "hasc:id":"NA.OS",
+        "iso:code":"NA-OS",
         "iso:id":"NA-OS",
         "qs_pg:id":934205,
         "unlc:id":"NA-OS",
         "wd:id":"Q764385",
         "wk:page":"Omusati Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34d58a9b68857c4f32a3eee14f58e151",
+    "wof:geomhash":"094c0d15b78c79d195c53ea50b68ab72",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848275,
+    "wof:lastmodified":1695884923,
     "wof:name":"Omusati",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/27/85675227.geojson
+++ b/data/856/752/27/85675227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.739916,
-    "geom:area_square_m":8679546548.772205,
+    "geom:area_square_m":8679546930.657139,
     "geom:bbox":"15.282799,-19.330408,16.039896,-17.670628",
     "geom:latitude":-18.432287,
     "geom:longitude":15.722958,
@@ -299,17 +299,19 @@
         "gn:id":3371207,
         "gp:id":20069843,
         "hasc:id":"NA.ON",
+        "iso:code":"NA-ON",
         "iso:id":"NA-ON",
         "qs_pg:id":1085061,
         "unlc:id":"NA-ON",
         "wd:id":"Q534528",
         "wk:page":"Oshana Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"80c1432adee9786ec2a70640f4f9f406",
+    "wof:geomhash":"10fcfc34812f7cd8645ce1f236ef05dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848273,
+    "wof:lastmodified":1695884922,
     "wof:name":"Oshana",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/31/85675231.geojson
+++ b/data/856/752/31/85675231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.910531,
-    "geom:area_square_m":10732802789.026371,
+    "geom:area_square_m":10732802227.807072,
     "geom:bbox":"15.550685,-17.928992,18.002351,-17.389528",
     "geom:latitude":-17.584063,
     "geom:longitude":16.813477,
@@ -293,17 +293,19 @@
         "gn:id":3371203,
         "gp:id":20069840,
         "hasc:id":"NA.OW",
+        "iso:code":"NA-OW",
         "iso:id":"NA-OW",
         "qs_pg:id":211880,
         "unlc:id":"NA-OW",
         "wd:id":"Q845702",
         "wk:page":"Ohangwena Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"94def6fd72cdba99cfa1d615ca1a7c9d",
+    "wof:geomhash":"cacbbe3b9d34e11c002f7f802749a694",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848275,
+    "wof:lastmodified":1695884923,
     "wof:name":"Ohangwena",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/35/85675235.geojson
+++ b/data/856/752/35/85675235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.406657,
-    "geom:area_square_m":84969987657.086411,
+    "geom:area_square_m":84969988537.991623,
     "geom:bbox":"17.957242,-23.870628,20.998754,-20.240375",
     "geom:latitude":-21.890057,
     "geom:longitude":19.465429,
@@ -272,17 +272,19 @@
         "gn:id":3371205,
         "gp:id":20069836,
         "hasc:id":"NA.OH",
+        "iso:code":"NA-OH",
         "iso:id":"NA-OH",
         "qs_pg:id":1084968,
         "unlc:id":"NA-OH",
         "wd:id":"Q838775",
         "wk:page":"Omaheke Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7befeb23e7d26e93ae5394c75118da0",
+    "wof:geomhash":"8fcb187baf5edfeba990130939b64f1d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +301,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848273,
+    "wof:lastmodified":1695884922,
     "wof:name":"Omaheke",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/856/752/43/85675243.geojson
+++ b/data/856/752/43/85675243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.307767,
-    "geom:area_square_m":38763875619.994148,
+    "geom:area_square_m":38763875644.345276,
     "geom:bbox":"15.841179,-19.532283,18.199862,-17.692886",
     "geom:latitude":-18.598763,
     "geom:longitude":17.004817,
@@ -293,6 +293,7 @@
         "gn:id":3371208,
         "gp:id":20069841,
         "hasc:id":"NA.OT",
+        "iso:code":"NA-OT",
         "iso:id":"NA-OT",
         "loc:id":"n95911332",
         "qs_pg:id":895820,
@@ -300,11 +301,12 @@
         "wd:id":"Q876512",
         "wk:page":"Oshikoto Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NA",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d3f4bd7ce14737a7e3456db7ce898aa2",
+    "wof:geomhash":"d2a2c73d189eb2ab72a8b583f4fdbbf8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
         "afr",
         "eng"
     ],
-    "wof:lastmodified":1690848274,
+    "wof:lastmodified":1695884922,
     "wof:name":"Oshikoto",
     "wof:parent_id":85632535,
     "wof:placetype":"region",

--- a/data/890/443/131/890443131.geojson
+++ b/data/890/443/131/890443131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002272,
-    "geom:area_square_m":25871462.879138,
+    "geom:area_square_m":25871337.030649,
     "geom:bbox":"14.477861,-22.984314,14.546215,-22.917004",
     "geom:latitude":-22.953532,
     "geom:longitude":14.513128,
@@ -105,12 +105,13 @@
         "wd:id":"Q4018062",
         "wk:page":"Walvis Bay Urban"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NA",
     "wof:created":1469052402,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b812e903f0f6ab522672f1c479896b6f",
+    "wof:geomhash":"10cf85fff03e86c1f12a806db433d802",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":890443131,
-    "wof:lastmodified":1690848294,
+    "wof:lastmodified":1695886801,
     "wof:name":"Walvisbay Urban",
     "wof:parent_id":85675213,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.